### PR TITLE
Add getAttributes method on the context object

### DIFF
--- a/lib/l20n.js
+++ b/lib/l20n.js
@@ -77,45 +77,58 @@ L20n.Context = function() {
         this.onASTReady();
       }
     },
-    get: function(id, data) {
-      if (!mCompiled)
-        throw "Error"
-      let entity = null;
-      try {
-        entity = mObjects['entries'][id]
-      } catch(e) {
-        throw "No such entity: "+id
-      }
-      if (entity.local)
-        throw "This entity is local"
+    _getArgs: function(data) {
       let args = Object.create(mObjects['ctxdata'])
       if (data) {
         for (let i in data) {
           args[i] = data[i]
         }
       }
+      return args
+    },
+    get: function(id, data) {
+      if (!mCompiled)
+        throw "Error"
+      let entity = mObjects['entries'][id]
+      if (!entity || entity.local) {
+        console.warn("No such entity: " + id)
+        return null
+      }
+      let args = this._getArgs(data)
       return entity.get(mObjects['entries'], args)
     },
     getAttribute: function(id, attr, data) {
       if (!mCompiled)
         throw "Error"
-      let entity = null;
-      try {
-        entity = mObjects['entries'][id]
-      } catch(e) {
-        throw "No such entity: "+id
+      let entity = mObjects['entries'][id]
+      if (!entity || entity.local) {
+        console.warn("No such entity: " + id)
+        return null
       }
-      if (entity.local)
-        throw "This entity is local"
-      if (entity.attributes[attr].local)
-        throw "This attribute is local"
-      let args = Object.create(mObjects['ctxdata'])
-      if (data) {
-        for (let i in data) {
-          args[i] = data[i]
-        }
+      let attribute = entity.attributes[attr]
+      if (!attribute || attribute.local) {
+        console.warn("No such attribute: " + attr)
+        return null
       }
+      let args = this._getArgs(data)
       return entity.getAttribute(attr, mObjects['entries'], args)
+    },
+    getAttributes: function(id, data) {
+      if (!mCompiled)
+        throw "Error"
+      let entity = mObjects['entries'][id]
+      if (!entity || entity.local) {
+        console.warn("No such entity: " + id)
+        return null
+      }
+      let args = this._getArgs(data)
+      let attributes = {};
+      for (let attr in entity.attributes) {
+        let attribute = entity.attributes[attr]
+        if (!attribute.local)
+          attributes[attr] = entity.getAttribute(attr, mObjects['entries'], args)
+      }
+      return attributes
     },
     getEntity: function() {
     },


### PR DESCRIPTION
1. add getAttributes which is used by l20n-xml.js
2. don't distinguish between a non-existing entity and a local entity.  From the point of view of the user of the context, they're the same, i.e. not available.
3. don't throw on missing entities, just log a warning and gracefully return null
