### PR TITLE
Error fallback

### DIFF
--- a/lib/l20n.js
+++ b/lib/l20n.js
@@ -659,21 +659,22 @@
       uris.push(uri);
       meta.importResource(uri, _ifComplete(meta, compile), 
                           invalidateOnIntegrityError,  0, async);
+      return true;
     };
 
     this.freeze = function ctx_freeze() {
       isFrozen = true;
       totalResources = uris.length;
       _ifComplete(meta, compile)();
+      return true;
     };
 
     this.get = function ctx_get(id, data, callback, fallback) {
       if (callback === undefined) {
         return getSync(id, data);
-      } else {
-        getAsync(id, data, callback, fallback);
-        return null;
       }
+      getAsync(id, data, callback, fallback);
+      return null;
     };
 
     this.getAttribute = function ctx_getAttribute(id, attr, data) {


### PR DESCRIPTION
This pull request implements three types of fallback:
- scheme fallback, which is a feature of the `l10n:` scheme;  you can define more than one scheme, and the context will try to find the LOL file in all of them, until it finds one,
- resource fallback, when a LOL cannot be found; in this case, create a subcontext and always use it, as the original context is not unusable (it's not integral anymore)
- entity fallback, when the context is ready, but a requested entity cannot be found;  create a subcontext synchronously and get the entity from the subcontext.

(possibly a follow-up issue:  what should happen when the entity exists, but doesn't compile properly, e.g. due to a reference to a non-existing entity)?
