### PR TITLE
Fire the ready event when the context, or its subctx is ready

### DIFF
--- a/lib/l20n.js
+++ b/lib/l20n.js
@@ -635,7 +635,7 @@
     });
 
     this.getLocale = function ctx_getLocale() {
-      if (settings.locales.length == 0) {
+      if (!settings.locales || settings.locales.length == 0) {
         return null;
       }
       return settings.locales[0];


### PR DESCRIPTION
This fixes #6
