### PR TITLE
l10n.js use of for...of does not work with uglifyjs or ES5-only uses

### DIFF
--- a/bindings/l20n/buildtime.js
+++ b/bindings/l20n/buildtime.js
@@ -28,9 +28,10 @@ function initResources(callback) {
                          .querySelectorAll('link[type="application/l10n"]');
   var iniLinks = [];
   var containsFetchableLocale = false;
-  var link;
+  var i;
 
-  for (link of resLinks) {
+  for (i = 0; i < resLinks.length; i++) {
+    var link = resLinks[i];
     var url = link.getAttribute('href');
     var type = url.substr(url.lastIndexOf('.') + 1);
     if (type === 'ini') {
@@ -58,8 +59,8 @@ function initResources(callback) {
     }
   }
 
-  for (link of iniLinks) {
-    L10n.loadINI.call(this, link, onIniLoaded);
+  for (i = 0; i < iniLinks.length; i++) {
+    L10n.loadINI.call(this, iniLinks[i], onIniLoaded);
   }
 }
 

--- a/bindings/l20n/dom.js
+++ b/bindings/l20n/dom.js
@@ -11,8 +11,9 @@ function translateFragment(element) {
   }
   translateElement.call(this, element);
 
-  for (var node of getTranslatableChildren(element)) {
-    translateElement.call(this, node);
+  var nodes = getTranslatableChildren(element);
+  for (var i = 0; i < nodes.length; i++ ) {
+    translateElement.call(this, nodes[i]);
   }
 }
 

--- a/bindings/l20n/ini.js
+++ b/bindings/l20n/ini.js
@@ -56,7 +56,8 @@ function parseINI(source, iniPath) {
   var uris = [];
   var match;
 
-  for (var line of entries) {
+  for (var i = 0; i < entries.length; i++) {
+    var line = entries[i];
     // we only care about en-US resources
     if (genericSection && iniPatterns['import'].test(line)) {
       match = iniPatterns['import'].exec(line);

--- a/bindings/l20n/runtime.js
+++ b/bindings/l20n/runtime.js
@@ -157,9 +157,10 @@ function initResources() {
   var resLinks = document.head
                          .querySelectorAll('link[type="application/l10n"]');
   var iniLinks = [];
-  var link;
+  var i;
 
-  for (link of resLinks) {
+  for (i = 0; i < resLinks.length; i++) {
+    var link = resLinks[i];
     var url = link.getAttribute('href');
     var type = url.substr(url.lastIndexOf('.') + 1);
     if (type === 'ini') {
@@ -183,8 +184,8 @@ function initResources() {
     }
   }
 
-  for (link of iniLinks) {
-    loadINI.call(this, link, onIniLoaded.bind(this));
+  for (i = 0; i < iniLinks.length; i++) {
+    loadINI.call(this, iniLinks[i], onIniLoaded.bind(this));
   }
 }
 


### PR DESCRIPTION
Originally reported here:
https://bugzilla.mozilla.org/show_bug.cgi?id=1002920

This pull request uses plain for loops instead of for...in loops so that the code is ES5 friendly, which allows wider use and tool support.

Just transferring the changes done in this pull request:
https://github.com/mozilla-b2g/gaia/pull/18771

to the source area. I'll merge that other pull request though to gaia once travis reports green.
