### PR TITLE
Fix bug where the extend function within Context does not handle data wi...

### DIFF
--- a/lib/l20n/context.js
+++ b/lib/l20n/context.js
@@ -258,7 +258,7 @@ define(function (require, exports) {
         if (src[key] === undefined) {
           // un-define (remove) the property from dst
           delete dst[key];
-        } else if (typeof src[key] !== 'object') {
+        } else if (src[key] === null || typeof src[key] !== 'object') {
           // if the source property is a primitive, just copy it overwriting 
           // whatever the destination property is
           dst[key] = src[key];


### PR DESCRIPTION
In Javascript typeof null === "object" despite null not being a proper object. The code assumes (during a deep copy) that anything that has typeof 'object' in javascript is an Object. 

Fixed by explicit null check in deep copy.

see: https://bugzilla.mozilla.org/show_bug.cgi?id=1057334
