### PR TITLE
Add the `default_locale` property in the manifest

### DIFF
--- a/docs/html.md
+++ b/docs/html.md
@@ -59,6 +59,7 @@ An example of the manifest file:
     
 ```json
 {
+  "default_locale": "en-US",
   "locales": [
     "en-US",
     "pl"


### PR DESCRIPTION
Without any `default_locale` property, the `registerLocales` function is called with `(undefined, […])`. Because the first argument `defLocale` is undefined, the function returns without adding any available locales. So, the manifest is silently skipped.