### PR TITLE
Wait with additional langs

### DIFF
--- a/build/config/webpack.js
+++ b/build/config/webpack.js
@@ -48,12 +48,14 @@ module.exports = {
           whitelist: [
             'strict',
             'es6.modules',
+            'es6.classes',
             'es6.destructuring',
             'es6.arrowFunctions',
             'es6.properties.shorthand',
             'es6.forOf',
             'es6.spread',
             'es6.parameters.rest',
+            'es6.parameters.default',
             'es6.blockScoping'
           ],
         }

--- a/src/bindings/html/dom.js
+++ b/src/bindings/html/dom.js
@@ -50,7 +50,6 @@ function getTranslatables(element) {
 }
 
 export function translateDocument(ctx, obs, langs, doc) {
-  //XXX langs currently cannot be a promise 
   let setDOMLocalized = function() {
     doc.localized = true;
     dispatchEvent(doc, 'DOMLocalized', langs);

--- a/src/bindings/html/dom.js
+++ b/src/bindings/html/dom.js
@@ -68,6 +68,29 @@ export function translateDocument(ctx, obs, langs, doc) {
     });
 }
 
+export function translateMutations(ctx, obs, langs, mutations) {
+  let targets = new Set();
+
+  for (let mutation of mutations) {
+    switch (mutation.type) {
+      case 'attributes':
+        translateElement(ctx, obs, langs, mutation.target);
+        break;
+      case 'childList':
+        for (let addedNode of mutation.addedNodes) {
+          if (addedNode.nodeType === Node.ELEMENT_NODE) {
+            targets.add(addedNode);
+          }
+        }
+    }
+  }
+
+  targets.forEach(
+    target => target.childElementCount ?
+      translateFragment(ctx, obs, langs, target) :
+      translateElement(ctx, obs, langs, target));
+}
+
 export function translateFragment(ctx, obs, langs, frag) {
   return Promise.all(
     getTranslatables(frag).map(

--- a/src/bindings/html/langs.js
+++ b/src/bindings/html/langs.js
@@ -1,7 +1,6 @@
 'use strict';
 
 import { prioritizeLocales } from '../../lib/intl';
-import { initViews } from './service';
 import { qps } from '../../lib/pseudo';
 
 const rtlList = ['ar', 'he', 'fa', 'ps', 'qps-plocm', 'ur'];
@@ -16,27 +15,28 @@ export function getAdditionalLanguages() {
 }
 
 export function onlanguagechage(
-  appVersion, defaultLang, availableLangs, requestedLangs) {
+  fn, appVersion, defaultLang, availableLangs, requestedLangs) {
 
   return this.languages = Promise.all([
     getAdditionalLanguages(), this.languages]).then(
-      ([additionalLangs, prevLangs]) => changeLanguage.call(
-        this, appVersion, defaultLang, availableLangs, additionalLangs,
+      ([additionalLangs, prevLangs]) => changeLanguage(
+        fn, appVersion, defaultLang, availableLangs, additionalLangs,
         prevLangs, requestedLangs || navigator.languages));
 }
 
 export function onadditionallanguageschange(
-  appVersion, defaultLang, availableLangs, additionalLangs, requestedLangs) {
+  fn, appVersion, defaultLang, availableLangs, additionalLangs,
+  requestedLangs) {
 
   return this.languages = this.languages.then(
-    prevLangs => changeLanguage.call(
-      this, appVersion, defaultLang, availableLangs, additionalLangs,
+    prevLangs => changeLanguage(
+      fn, appVersion, defaultLang, availableLangs, additionalLangs,
       prevLangs, requestedLangs || navigator.languages));
 }
 
 
 export function changeLanguage(
-  appVersion, defaultLang, availableLangs, additionalLangs, prevLangs,
+  fn, appVersion, defaultLang, availableLangs, additionalLangs, prevLangs,
   requestedLangs) {
 
   let allAvailableLangs = Object.keys(availableLangs).concat(
@@ -51,7 +51,7 @@ export function changeLanguage(
   }));
 
   if (!arrEqual(prevLangs, newLangs)) {
-    initViews.call(this, langs);
+    fn(langs);
   }
 
   return langs;

--- a/src/bindings/html/langs.js
+++ b/src/bindings/html/langs.js
@@ -5,16 +5,7 @@ import { qps } from '../../lib/pseudo';
 
 const rtlList = ['ar', 'he', 'fa', 'ps', 'qps-plocm', 'ur'];
 
-export function getAdditionalLanguages() {
-  if (navigator.mozApps && navigator.mozApps.getAdditionalLanguages) {
-    return navigator.mozApps.getAdditionalLanguages().catch(
-      () => []);
-  }
-
-  return Promise.resolve([]);
-}
-
-export function changeLanguage(
+export function negotiateLanguages(
   fn, appVersion, defaultLang, availableLangs, additionalLangs, prevLangs,
   requestedLangs) {
 

--- a/src/bindings/html/langs.js
+++ b/src/bindings/html/langs.js
@@ -14,27 +14,6 @@ export function getAdditionalLanguages() {
   return Promise.resolve([]);
 }
 
-export function onlanguagechage(
-  fn, appVersion, defaultLang, availableLangs, requestedLangs) {
-
-  return this.languages = Promise.all([
-    getAdditionalLanguages(), this.languages]).then(
-      ([additionalLangs, prevLangs]) => changeLanguage(
-        fn, appVersion, defaultLang, availableLangs, additionalLangs,
-        prevLangs, requestedLangs || navigator.languages));
-}
-
-export function onadditionallanguageschange(
-  fn, appVersion, defaultLang, availableLangs, additionalLangs,
-  requestedLangs) {
-
-  return this.languages = this.languages.then(
-    prevLangs => changeLanguage(
-      fn, appVersion, defaultLang, availableLangs, additionalLangs,
-      prevLangs, requestedLangs || navigator.languages));
-}
-
-
 export function changeLanguage(
   fn, appVersion, defaultLang, availableLangs, additionalLangs, prevLangs,
   requestedLangs) {

--- a/src/bindings/html/service.js
+++ b/src/bindings/html/service.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import Env from '../../lib/env';
-import { View, init as initView } from './view';
+import { View, translate } from './view';
 import { getMeta } from './head';
 import { getAdditionalLanguages, changeLanguage } from './langs';
 
@@ -12,9 +12,9 @@ export const L10n = {
   requestLanguages: null
 };
 
-export function initViews(langs) {
+export function translateViews(langs) {
   return Promise.all(
-    this.views.map(view => initView.call(view, langs)));
+    this.views.map(view => translate.call(view, langs)));
 }
 
 export function onlanguagechage(
@@ -23,7 +23,7 @@ export function onlanguagechage(
   return this.languages = Promise.all([
     getAdditionalLanguages(), this.languages]).then(
       ([additionalLangs, prevLangs]) => changeLanguage(
-        initViews.bind(this), appVersion, defaultLang, availableLangs,
+        translateViews.bind(this), appVersion, defaultLang, availableLangs,
         additionalLangs, prevLangs, requestedLangs || navigator.languages));
 }
 
@@ -33,7 +33,7 @@ export function onadditionallanguageschange(
 
   return this.languages = this.languages.then(
     prevLangs => changeLanguage(
-      initViews.bind(this), appVersion, defaultLang, availableLangs,
+      translateViews.bind(this), appVersion, defaultLang, availableLangs,
       additionalLangs, prevLangs, requestedLangs || navigator.languages));
 }
 
@@ -48,7 +48,7 @@ export function init(fetch, additionalLangsAtLaunch) {
     document.l10n = new View(this, document));
 
   let setLanguage = additionalLangs => changeLanguage(
-    initViews.bind(this), appVersion, defaultLang, availableLangs,
+    translateViews.bind(this), appVersion, defaultLang, availableLangs,
     additionalLangs, [], navigator.languages);
 
   this.languages = additionalLangsAtLaunch.then(

--- a/src/bindings/html/service.js
+++ b/src/bindings/html/service.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import Env from '../../lib/env';
+import { Env } from '../../lib/env';
 import { View, translate } from './view';
 import { getMeta } from './head';
 import { negotiateLanguages } from './langs';

--- a/src/bindings/html/service.js
+++ b/src/bindings/html/service.js
@@ -6,7 +6,7 @@ import { getMeta } from './head';
 import { negotiateLanguages } from './langs';
 
 export class Service {
-  constructor(fetch, additionalLangsAtLaunch) {
+  constructor(fetch) {
     let meta = getMeta(document.head);
     this.defaultLanguage = meta.defaultLang;
     this.availableLanguages = meta.availableLangs;
@@ -19,7 +19,7 @@ export class Service {
     ];
 
     this.languages = changeLanguages.call(
-      this, additionalLangsAtLaunch, navigator.languages);
+      this, getAdditionalLanguages(), navigator.languages);
   }
 
   requestLanguages(requestedLangs = navigator.languages) {

--- a/src/bindings/html/service.js
+++ b/src/bindings/html/service.js
@@ -17,5 +17,5 @@ export function initViews(langs) {
 function initView(view, langs) {
   dispatchEvent(view.doc, 'supportedlanguageschange', langs);
   return view.ctx.fetch(langs, 1).then(
-    translateDocument.bind(view, view.doc, langs));
+    translateDocument.bind(null, view, view.doc, langs));
 }

--- a/src/bindings/html/service.js
+++ b/src/bindings/html/service.js
@@ -1,21 +1,68 @@
 'use strict';
 
-import { translateDocument, dispatchEvent } from './dom';
+import Env from '../../lib/env';
+import { View, init as initView } from './view';
+import { getMeta } from './head';
+import { getAdditionalLanguages, changeLanguage } from './langs';
 
 export const L10n = {
   views: [],
   env: null,
   languages: null,
-  change: null
+  requestLanguages: null
 };
 
 export function initViews(langs) {
   return Promise.all(
-    this.views.map(view => initView(view, langs)));
+    this.views.map(view => initView.call(view, langs)));
 }
 
-function initView(view, langs) {
-  dispatchEvent(view.doc, 'supportedlanguageschange', langs);
-  return view.ctx.fetch(langs, 1).then(
-    translateDocument.bind(null, view, view.doc, langs));
+export function onlanguagechage(
+  appVersion, defaultLang, availableLangs, requestedLangs) {
+
+  return this.languages = Promise.all([
+    getAdditionalLanguages(), this.languages]).then(
+      ([additionalLangs, prevLangs]) => changeLanguage(
+        initViews.bind(this), appVersion, defaultLang, availableLangs,
+        additionalLangs, prevLangs, requestedLangs || navigator.languages));
+}
+
+export function onadditionallanguageschange(
+  appVersion, defaultLang, availableLangs, additionalLangs,
+  requestedLangs) {
+
+  return this.languages = this.languages.then(
+    prevLangs => changeLanguage(
+      initViews.bind(this), appVersion, defaultLang, availableLangs,
+      additionalLangs, prevLangs, requestedLangs || navigator.languages));
+}
+
+export function init(fetch, additionalLangsAtLaunch) {
+  let {
+   defaultLang, availableLangs, appVersion
+  } = getMeta(document.head);
+
+  this.env = new Env(
+    document.URL, defaultLang, fetch.bind(null, appVersion));
+  this.views.push(
+    document.l10n = new View(this, document));
+
+  let setLanguage = additionalLangs => changeLanguage(
+    initViews.bind(this), appVersion, defaultLang, availableLangs,
+    additionalLangs, [], navigator.languages);
+
+  this.languages = additionalLangsAtLaunch.then(
+    setLanguage, setLanguage);
+
+  this.requestLanguages = onlanguagechage.bind(
+    this, appVersion, defaultLang, availableLangs);
+
+  window.addEventListener('languagechange',
+    () => onlanguagechage.call(
+      this, appVersion, defaultLang, availableLangs,
+      navigator.languages));
+  document.addEventListener('additionallanguageschange',
+    evt => onadditionallanguageschange.call(
+      this, appVersion, defaultLang, availableLangs, evt.detail,
+      navigator.languages));
 }

--- a/src/bindings/html/service.js
+++ b/src/bindings/html/service.js
@@ -5,12 +5,44 @@ import { View, translate } from './view';
 import { getMeta } from './head';
 import { getAdditionalLanguages, changeLanguage } from './langs';
 
-export const L10n = {
-  views: [],
-  env: null,
-  languages: null,
-  requestLanguages: null
-};
+export class Service {
+  constructor(fetch, bootstrap = Promise.resolve()) {
+    let {
+     defaultLang, availableLangs, appVersion
+    } = getMeta(document.head);
+
+    this.env = new Env(
+      document.URL, defaultLang, fetch.bind(null, appVersion));
+    this.views = [
+      document.l10n = new View(this, document)
+    ];
+
+    let setLanguage = additionalLangs => changeLanguage(
+      translateViews.bind(this), appVersion, defaultLang, availableLangs,
+      additionalLangs, [], navigator.languages);
+
+    this.languages = bootstrap.then(
+      setLanguage, setLanguage);
+
+    this.requestLanguages = onlanguagechage.bind(
+      this, appVersion, defaultLang, availableLangs);
+
+    this.handleEvent = function(evt) {
+      switch(evt.type) {
+        case 'languagechange':
+          onlanguagechage.call(
+            this, appVersion, defaultLang, availableLangs,
+            navigator.languages);
+          break;
+        case 'additionallanguageschange':
+          onadditionallanguageschange.call(
+            this, appVersion, defaultLang, availableLangs, evt.detail,
+            navigator.languages);
+        break;
+      }
+    };
+  }
+}
 
 export function translateViews(langs) {
   return Promise.all(
@@ -35,34 +67,4 @@ export function onadditionallanguageschange(
     prevLangs => changeLanguage(
       translateViews.bind(this), appVersion, defaultLang, availableLangs,
       additionalLangs, prevLangs, requestedLangs || navigator.languages));
-}
-
-export function init(fetch, additionalLangsAtLaunch) {
-  let {
-   defaultLang, availableLangs, appVersion
-  } = getMeta(document.head);
-
-  this.env = new Env(
-    document.URL, defaultLang, fetch.bind(null, appVersion));
-  this.views.push(
-    document.l10n = new View(this, document));
-
-  let setLanguage = additionalLangs => changeLanguage(
-    translateViews.bind(this), appVersion, defaultLang, availableLangs,
-    additionalLangs, [], navigator.languages);
-
-  this.languages = additionalLangsAtLaunch.then(
-    setLanguage, setLanguage);
-
-  this.requestLanguages = onlanguagechage.bind(
-    this, appVersion, defaultLang, availableLangs);
-
-  window.addEventListener('languagechange',
-    () => onlanguagechage.call(
-      this, appVersion, defaultLang, availableLangs,
-      navigator.languages));
-  document.addEventListener('additionallanguageschange',
-    evt => onadditionallanguageschange.call(
-      this, appVersion, defaultLang, availableLangs, evt.detail,
-      navigator.languages));
 }

--- a/src/bindings/html/service.js
+++ b/src/bindings/html/service.js
@@ -13,7 +13,7 @@ export class Service {
     this.appVersion = meta.appVersion;
 
     this.env = new Env(
-      document.URL, this.defaultLanguage, fetch.bind(null, this.appVersion));
+      this.defaultLanguage, fetch.bind(null, this.appVersion));
     this.views = [
       document.l10n = new View(this, document)
     ];

--- a/src/bindings/html/service.js
+++ b/src/bindings/html/service.js
@@ -25,46 +25,29 @@ export class Service {
       setLanguage, setLanguage);
 
     this.requestLanguages = onlanguagechage.bind(
-      this, appVersion, defaultLang, availableLangs);
+      this, appVersion, defaultLang, availableLangs, null);
 
     this.handleEvent = function(evt) {
-      switch(evt.type) {
-        case 'languagechange':
-          onlanguagechage.call(
-            this, appVersion, defaultLang, availableLangs,
-            navigator.languages);
-          break;
-        case 'additionallanguageschange':
-          onadditionallanguageschange.call(
-            this, appVersion, defaultLang, availableLangs, evt.detail,
-            navigator.languages);
-        break;
-      }
+      return onlanguagechage.call(
+        this, appVersion, defaultLang, availableLangs, evt.detail,
+        navigator.languages);
     };
   }
 }
 
-export function translateViews(langs) {
+function translateViews(langs) {
   return Promise.all(
     this.views.map(view => translate.call(view, langs)));
 }
 
 export function onlanguagechage(
-  appVersion, defaultLang, availableLangs, requestedLangs) {
+  appVersion, defaultLang, availableLangs,
+  additionalLangs = getAdditionalLanguages(),
+  requestedLangs = navigator.languages) {
 
   return this.languages = Promise.all([
-    getAdditionalLanguages(), this.languages]).then(
+    additionalLangs, this.languages]).then(
       ([additionalLangs, prevLangs]) => changeLanguage(
         translateViews.bind(this), appVersion, defaultLang, availableLangs,
-        additionalLangs, prevLangs, requestedLangs || navigator.languages));
-}
-
-export function onadditionallanguageschange(
-  appVersion, defaultLang, availableLangs, additionalLangs,
-  requestedLangs) {
-
-  return this.languages = this.languages.then(
-    prevLangs => changeLanguage(
-      translateViews.bind(this), appVersion, defaultLang, availableLangs,
-      additionalLangs, prevLangs, requestedLangs || navigator.languages));
+        additionalLangs, prevLangs, requestedLangs));
 }

--- a/src/bindings/html/view.js
+++ b/src/bindings/html/view.js
@@ -2,7 +2,8 @@
 
 import { getResourceLinks } from '../../bindings/html/head';
 import {
-  setL10nAttributes, getL10nAttributes, translateFragment, translateElement
+  setL10nAttributes, getL10nAttributes, dispatchEvent,
+  translateDocument, translateFragment, translateElement
 } from './dom';
 
 const observerConfig = {
@@ -50,6 +51,12 @@ export class View {
 
 View.prototype.setAttributes = setL10nAttributes;
 View.prototype.getAttributes = getL10nAttributes;
+
+export function init(langs) {
+  dispatchEvent(this.doc, 'supportedlanguageschange', langs);
+  return this.ctx.fetch(langs, 1).then(
+    translateDocument.bind(null, this, this.doc, langs));
+}
 
 function onMutations(view, mutations) {
   let mutation;

--- a/src/bindings/html/view.js
+++ b/src/bindings/html/view.js
@@ -29,7 +29,8 @@ export class View {
     });
 
     let observer = new MutationObserver(
-      mutations => onMutations(this, mutations));
+      mutations => this.service.languages.then(
+        langs => onMutations(this.ctx, this, langs, mutations)));
     this.observe = () => observer.observe(this.doc, observerConfig);
     this.disconnect = () => observer.disconnect();
 
@@ -37,15 +38,18 @@ export class View {
   }
 
   formatValue(id, args) {
-    return this.ctx.formatValue(this.service.languages, id, args);
+    return this.service.languages.then(
+      langs => this.ctx.formatValue(langs, id, args));
   }
 
   formatEntity(id, args) {
-    return this.ctx.formatEntity(this.service.languages, id, args);
+    return this.service.languages.then(
+      langs => this.ctx.formatEntity(langs, id, args));
   }
 
   translateFragment(frag) {
-    return translateFragment(this.ctx, this, this.service.languages, frag);
+    return this.service.languages.then(
+      langs => translateFragment(this.ctx, this, langs, frag));
   }
 }
 
@@ -57,14 +61,13 @@ export function translate(langs) {
   return translateDocument(this.ctx, this, langs, this.doc);
 }
 
-function onMutations(view, mutations) {
-  let {ctx, service} = view;
+function onMutations(ctx, obs, langs, mutations) {
   let targets = new Set();
 
   for (let mutation of mutations) {
     switch (mutation.type) {
       case 'attributes':
-        translateElement(ctx, view, service.languages, mutation.target);
+        translateElement(ctx, obs, langs, mutation.target);
         break;
       case 'childList':
         for (let addedNode of mutation.addedNodes) {
@@ -77,6 +80,6 @@ function onMutations(view, mutations) {
 
   targets.forEach(
     target => target.childElementCount ?
-      translateFragment(ctx, view, service.languages, target) :
-      translateElement(ctx, view, service.languages, target));
+      translateFragment(ctx, obs, langs, target) :
+      translateElement(ctx, obs, langs, target));
 }

--- a/src/bindings/html/view.js
+++ b/src/bindings/html/view.js
@@ -54,8 +54,7 @@ View.prototype.getAttributes = getL10nAttributes;
 
 export function init(langs) {
   dispatchEvent(this.doc, 'supportedlanguageschange', langs);
-  return this.ctx.fetch(langs, 1).then(
-    translateDocument.bind(null, this, this.doc, langs));
+  return translateDocument(this, this.doc, langs);
 }
 
 function onMutations(view, mutations) {

--- a/src/bindings/html/view.js
+++ b/src/bindings/html/view.js
@@ -27,7 +27,8 @@ export class View {
       doc.addEventListener('DOMLocalized', viewReady);
     });
 
-    let observer = new MutationObserver(onMutations.bind(this));
+    let observer = new MutationObserver(
+      mutations => onMutations(this, mutations));
     this.observe = () => observer.observe(this.doc, observerConfig);
     this.disconnect = () => observer.disconnect();
 
@@ -41,13 +42,16 @@ export class View {
   formatEntity(id, args) {
     return this.ctx.formatEntity(this.service.languages, id, args);
   }
+
+  translateFragment(frag) {
+    return translateFragment(this, frag);
+  }
 }
 
 View.prototype.setAttributes = setL10nAttributes;
 View.prototype.getAttributes = getL10nAttributes;
-View.prototype.translateFragment = translateFragment;
 
-function onMutations(mutations) {
+function onMutations(view, mutations) {
   let mutation;
   let targets = new Set();
 
@@ -64,15 +68,15 @@ function onMutations(mutations) {
     }
 
     if (mutation.type === 'attributes') {
-      translateElement.call(this, mutation.target);
+      translateElement(view, mutation.target);
     }
   }
 
   targets.forEach(function(target) {
     if (target.childElementCount) {
-      translateFragment.call(this, target);
+      translateFragment(view, target);
     } else if (target.hasAttribute('data-l10n-id')) {
-      translateElement.call(this, target);
+      translateElement(view, target);
     }
-  }, this);
+  });
 }

--- a/src/bindings/html/view.js
+++ b/src/bindings/html/view.js
@@ -52,7 +52,7 @@ export class View {
 View.prototype.setAttributes = setL10nAttributes;
 View.prototype.getAttributes = getL10nAttributes;
 
-export function init(langs) {
+export function translate(langs) {
   dispatchEvent(this.doc, 'supportedlanguageschange', langs);
   return translateDocument(this.ctx, this, langs, this.doc);
 }

--- a/src/lib/context.js
+++ b/src/lib/context.js
@@ -2,9 +2,9 @@
 
 import { L10nError } from './errors';
 import { format } from './resolver';
-import getPluralRule from './plurals';
+import { getPluralRule } from './plurals';
 
-export default class Context {
+export class Context {
   constructor(env, resIds) {
     this._env = env;
     this._resIds = resIds;

--- a/src/lib/context.js
+++ b/src/lib/context.js
@@ -12,8 +12,7 @@ export default class Context {
 
   fetch(langs) {
     // XXX add arg: count of langs to fetch
-    return Promise.resolve(langs).then(
-      this._fetchResources.bind(this));
+    return this._fetchResources(langs);
   }
 
   formatValue(langs, id, args) {

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import Context from './context';
+import { Context } from './context';
 import { createEntry } from './resolver';
 import PropertiesParser from './format/properties/parser';
 import L20nParser from './format/l20n/parser';
@@ -13,7 +13,7 @@ const parsers = {
   json: null
 };
 
-export default class Env {
+export class Env {
   constructor(defaultLang, fetch) {
     this.defaultLang = defaultLang;
     this.fetch = fetch;

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -14,8 +14,7 @@ const parsers = {
 };
 
 export default class Env {
-  constructor(id, defaultLang, fetch) {
-    this.id = id;
+  constructor(defaultLang, fetch) {
     this.defaultLang = defaultLang;
     this.fetch = fetch;
 

--- a/src/lib/plurals.js
+++ b/src/lib/plurals.js
@@ -1,6 +1,6 @@
 'use strict';
 
-export default function getPluralRule(code) {
+export function getPluralRule(code) {
   var locales2rules = {
     'af': 3,
     'ak': 4,

--- a/src/runtime/node/index.js
+++ b/src/runtime/node/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import io from './io';
-import Env from '../../lib/env';
+import { fetch } from './io';
+import { Env } from '../../lib/env';
 
-export default {io, Env};
+export default { fetch, Env };

--- a/src/runtime/node/io.js
+++ b/src/runtime/node/io.js
@@ -1,11 +1,11 @@
 'use strict';
 
-import fs from 'fs';
+import { readFile } from 'fs';
 import { L10nError } from '../../lib/errors';
 
 function load(url) {
   return new Promise(function(resolve, reject) {
-    fs.readFile(url, function(err, data) {
+    readFile(url, function(err, data) {
       if (err) {
         reject(new L10nError(err.message));
       } else {
@@ -15,10 +15,8 @@ function load(url) {
   });
 }
 
-export default {
-  fetch: function(res, lang) {
-    let url = res.replace('{locale}', lang.code);
-    return res.endsWith('.json') ?
-      load(url).then(JSON.parse) : load(url);
-  }
-};
+export function fetch(res, lang) {
+  let url = res.replace('{locale}', lang.code);
+  return res.endsWith('.json') ?
+    load(url).then(JSON.parse) : load(url);
+}

--- a/src/runtime/web/index.js
+++ b/src/runtime/web/index.js
@@ -1,14 +1,8 @@
 'use strict';
 
-import io from './io';
-import Env from '../../lib/env';
-import { L10n } from '../../bindings/html/service';
-import { View } from '../../bindings/html/view';
-import { getMeta } from '../../bindings/html/head';
-import {
-  changeLanguage, onlanguagechage, onadditionallanguageschange,
-  getAdditionalLanguages
-} from '../../bindings/html/langs';
+import { fetch } from './io';
+import { L10n, init } from '../../bindings/html/service';
+import { getAdditionalLanguages } from '../../bindings/html/langs';
 
 const additionalLangsAtLaunch = getAdditionalLanguages();
 const readyStates = {
@@ -30,33 +24,5 @@ function whenInteractive(callback) {
   });
 }
 
-function init() {
-  let {
-   defaultLang, availableLangs, appVersion
-  } = getMeta(document.head);
-
-  this.env = new Env(
-    document.URL, defaultLang, io.fetch.bind(io, appVersion));
-  this.views.push(
-    document.l10n = new View(this, document));
-
-  let setLanguage = additionalLangs => changeLanguage.call(
-    this, appVersion, defaultLang, availableLangs, additionalLangs, [],
-    navigator.languages);
-
-  this.languages = additionalLangsAtLaunch.then(
-    setLanguage, setLanguage);
-
-  this.change = onlanguagechage.bind(
-    this, appVersion, defaultLang, availableLangs);
-
-  window.addEventListener('languagechange',
-    () => onlanguagechage.call(
-      this, appVersion, defaultLang, availableLangs, navigator.languages));
-  document.addEventListener('additionallanguageschange',
-    evt => onadditionallanguageschange.call(
-      this, appVersion, defaultLang, availableLangs, evt.detail,
-      navigator.languages));
-}
-
-whenInteractive(init.bind(window.L10n = L10n));
+whenInteractive(
+  init.bind(window.L10n = L10n, fetch, additionalLangsAtLaunch));

--- a/src/runtime/web/index.js
+++ b/src/runtime/web/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { fetch } from './io';
-import { L10n, init } from '../../bindings/html/service';
+import { Service } from '../../bindings/html/service';
 import { getAdditionalLanguages } from '../../bindings/html/langs';
 
 const additionalLangsAtLaunch = getAdditionalLanguages();
@@ -16,13 +16,18 @@ function whenInteractive(callback) {
     return callback();
   }
 
-  document.addEventListener('readystatechange', function l10n_onrsc() {
+  document.addEventListener('readystatechange', function onrsc() {
     if (readyStates[document.readyState] >= readyStates.interactive) {
-      document.removeEventListener('readystatechange', l10n_onrsc);
+      document.removeEventListener('readystatechange', onrsc);
       callback();
     }
   });
 }
 
-whenInteractive(
-  init.bind(window.L10n = L10n, fetch, additionalLangsAtLaunch));
+function init() {
+  window.L10n = new Service(fetch, additionalLangsAtLaunch);
+  window.addEventListener('languagechange', window.L10n);
+  document.addEventListener('additionallanguageschange', window.L10n);
+}
+
+whenInteractive(init);

--- a/src/runtime/web/index.js
+++ b/src/runtime/web/index.js
@@ -1,8 +1,7 @@
 'use strict';
 
 import { fetch } from './io';
-import { Service } from '../../bindings/html/service';
-import { getAdditionalLanguages } from '../../bindings/html/langs';
+import { Service, getAdditionalLanguages } from '../../bindings/html/service';
 
 const additionalLangsAtLaunch = getAdditionalLanguages();
 const readyStates = {

--- a/src/runtime/web/index.js
+++ b/src/runtime/web/index.js
@@ -1,9 +1,8 @@
 'use strict';
 
 import { fetch } from './io';
-import { Service, getAdditionalLanguages } from '../../bindings/html/service';
+import { Service } from '../../bindings/html/service';
 
-const additionalLangsAtLaunch = getAdditionalLanguages();
 const readyStates = {
   loading: 0,
   interactive: 1,
@@ -24,7 +23,7 @@ function whenInteractive(callback) {
 }
 
 function init() {
-  window.L10n = new Service(fetch, additionalLangsAtLaunch);
+  window.L10n = new Service(fetch);
   window.addEventListener('languagechange', window.L10n);
   document.addEventListener('additionallanguageschange', window.L10n);
 }

--- a/src/runtime/web/io.js
+++ b/src/runtime/web/io.js
@@ -58,10 +58,8 @@ const io = {
   },
 };
 
-export default {
-  fetch: function(ver, res, lang) {
-    let url = res.replace('{locale}', lang.code);
-    let type = res.endsWith('.json') ? 'json' : 'text';
-    return io[lang.src](lang.code, ver, url, type);
-  }
-};
+export function fetch(ver, res, lang) {
+  let url = res.replace('{locale}', lang.code);
+  let type = res.endsWith('.json') ? 'json' : 'text';
+  return io[lang.src](lang.code, ver, url, type);
+}

--- a/tests/lib/context/basic_test.js
+++ b/tests/lib/context/basic_test.js
@@ -25,7 +25,7 @@ describe('A simple context with one resource', function() {
   var env, ctx;
 
   beforeEach(function() {
-    env = new L20n.Env('test', 'en-US', fetch);
+    env = new L20n.Env('en-US', fetch);
     ctx = env.createContext([path + '/fixtures/basic.properties']);
   });
 

--- a/tests/lib/context/basic_test.js
+++ b/tests/lib/context/basic_test.js
@@ -9,13 +9,12 @@ if (typeof navigator !== 'undefined') {
 } else {
   var assert = require('assert');
   var L20n = {
-    Env: require('../../../src/lib/env'),
-    io: require('../../../src/runtime/node/io')
+    Env: require('../../../src/lib/env').Env,
+    fetch: require('../../../src/runtime/node/io').fetch
   };
   var path = __dirname + '/..';
 }
 
-var fetch = L20n.io.fetch.bind(L20n.io);
 var langs = [
   { code: 'en-US', src: 'app', dir: 'ltr' },
 ];
@@ -25,7 +24,7 @@ describe('A simple context with one resource', function() {
   var env, ctx;
 
   beforeEach(function() {
-    env = new L20n.Env('en-US', fetch);
+    env = new L20n.Env('en-US', L20n.fetch);
     ctx = env.createContext([path + '/fixtures/basic.properties']);
   });
 

--- a/tests/lib/context/format_test.js
+++ b/tests/lib/context/format_test.js
@@ -9,8 +9,8 @@ if (typeof navigator !== 'undefined') {
 } else {
   var assert = require('assert');
   var L20n = {
-    Env: require('../../../src/lib/env'),
-    io: require('../../../src/runtime/node/io')
+    Env: require('../../../src/lib/env').Env,
+    fetch: require('../../../src/runtime/node/io').fetch
   };
   var path = __dirname + '/..';
 }
@@ -21,7 +21,6 @@ function assertPromise(promise, expected, done) {
   }).then(done, done);
 }
 
-var fetch = L20n.io.fetch.bind(L20n.io);
 var langs = [
   { code: 'pl', src: 'app', dir: 'ltr' },
   { code: 'en-US', src: 'app', dir: 'ltr' },
@@ -31,7 +30,7 @@ describe('One fallback locale', function() {
   var env, ctx;
 
   beforeEach(function() {
-    env = new L20n.Env('en-US', fetch);
+    env = new L20n.Env('en-US', L20n.fetch);
     ctx = env.createContext([path + '/fixtures/{locale}.properties']);
   });
 

--- a/tests/lib/context/format_test.js
+++ b/tests/lib/context/format_test.js
@@ -31,7 +31,7 @@ describe('One fallback locale', function() {
   var env, ctx;
 
   beforeEach(function() {
-    env = new L20n.Env('test', 'en-US', fetch);
+    env = new L20n.Env('en-US', fetch);
     ctx = env.createContext([path + '/fixtures/{locale}.properties']);
   });
 

--- a/tests/lib/env/resCache.js
+++ b/tests/lib/env/resCache.js
@@ -9,14 +9,13 @@ if (typeof navigator !== 'undefined') {
 } else {
   var assert = require('assert');
   var L20n = {
-    Env: require('../../../src/lib/env'),
-    io: require('../../../src/runtime/node/io'),
+    Env: require('../../../src/lib/env').Env,
+    fetch: require('../../../src/runtime/node/io').fetch,
     L10nError: require('../../../src/lib/errors').L10nError
   };
   var path = __dirname + '/..';
 }
 
-var fetch = L20n.io.fetch.bind(L20n.io);
 var langs = [
   { code: 'en-US', src: 'app', dir: 'ltr' },
 ];
@@ -29,7 +28,7 @@ describe('Caching resources', function() {
   var res3 = path + '/fixtures/missing.properties';
 
   beforeEach(function(done) {
-    env = new L20n.Env('en-US', fetch);
+    env = new L20n.Env('en-US', L20n.fetch);
     ctx1 = env.createContext([res1, res3]);
     ctx2 = env.createContext([res1, res2]);
     Promise.all([

--- a/tests/lib/env/resCache.js
+++ b/tests/lib/env/resCache.js
@@ -29,7 +29,7 @@ describe('Caching resources', function() {
   var res3 = path + '/fixtures/missing.properties';
 
   beforeEach(function(done) {
-    env = new L20n.Env('test', 'en-US', fetch);
+    env = new L20n.Env('en-US', fetch);
     ctx1 = env.createContext([res1, res3]);
     ctx2 = env.createContext([res1, res2]);
     Promise.all([

--- a/tests/lib/env/resMap.js
+++ b/tests/lib/env/resMap.js
@@ -24,7 +24,7 @@ describe('Creating a context', function() {
   var res2 = path + '/fixtures/en-US.properties';
 
   beforeEach(function() {
-    env = new L20n.Env('test', 'en-US', fetch);
+    env = new L20n.Env('en-US', fetch);
   });
 
   it('populates resMap with one ctx', function() {

--- a/tests/lib/env/resMap.js
+++ b/tests/lib/env/resMap.js
@@ -9,13 +9,11 @@ if (typeof navigator !== 'undefined') {
 } else {
   var assert = require('assert');
   var L20n = {
-    Env: require('../../../src/lib/env'),
-    io: require('../../../src/runtime/node/io')
+    Env: require('../../../src/lib/env').Env,
+    fetch: require('../../../src/runtime/node/io').fetch
   };
   var path = __dirname + '/..';
 }
-
-var fetch = L20n.io.fetch.bind(L20n.io);
 
 
 describe('Creating a context', function() {
@@ -24,7 +22,7 @@ describe('Creating a context', function() {
   var res2 = path + '/fixtures/en-US.properties';
 
   beforeEach(function() {
-    env = new L20n.Env('en-US', fetch);
+    env = new L20n.Env('en-US', L20n.fetch);
   });
 
   it('populates resMap with one ctx', function() {

--- a/tests/lib/resolver/header.js
+++ b/tests/lib/resolver/header.js
@@ -9,7 +9,7 @@ if (typeof navigator !== 'undefined') {
     PropertiesParser:
       require('../../../src/lib/format/properties/parser'),
     Resolver: require('../../../src/lib/resolver'),
-    getPluralRule: require('../../../src/lib/plurals')
+    getPluralRule: require('../../../src/lib/plurals').getPluralRule
   };
 
   exports.Resolver = L10n.Resolver;


### PR DESCRIPTION
It turns out there's no value in calling `getAdditionalLanguages` early, before the `interactive` ready state fires.  In fact, it's a bit slower than simply calling it when the service is initialized.  Compare the following Raptor results from the Settings app:

```
Before                            Mean      Median    Min       Max       StdDev  p95     
--------------------------------  --------  --------  --------  --------  ------  --------
coldlaunch.navigationLoaded       860.200   846.500   815.000   962.000   39.242  962.000 
coldlaunch.navigationInteractive  860.300   847.000   815.000   962.000   39.207  962.000 
coldlaunch.contentInteractive     938.700   927.000   892.000   1043.000  40.482  1043.000
coldlaunch.startupPathEnd         2067.400  2066.500  1966.000  2160.000  48.092  2160.000
coldlaunch.visuallyLoaded         2626.100  2611.000  2528.000  2721.000  56.980  2721.000
coldlaunch.fullyLoaded            5217.200  5211.000  5183.000  5295.000  30.099  5295.000
coldlaunch.uss                    16.970    17.000    16.700    17.300    0.173   17.300  
coldlaunch.pss                    20.890    20.900    20.700    21.300    0.181   21.300  
coldlaunch.rss                    35.580    35.550    35.300    36.000    0.199   36.000  
```

```
After                             Mean      Median    Min       Max       StdDev  p95     
--------------------------------  --------  --------  --------  --------  ------  --------
coldlaunch.navigationLoaded       852.000   855.000   814.000   915.000   27.543  915.000 
coldlaunch.navigationInteractive  852.200   855.500   814.000   916.000   27.795  916.000 
coldlaunch.contentInteractive     931.900   937.000   886.000   990.000   28.452  990.000 
coldlaunch.startupPathEnd         2067.400  2079.000  1996.000  2109.000  34.404  2109.000
coldlaunch.visuallyLoaded         2590.000  2582.000  2516.000  2695.000  51.585  2695.000
coldlaunch.fullyLoaded            5211.700  5219.500  5141.000  5265.000  35.154  5265.000
coldlaunch.uss                    16.930    16.900    16.700    17.300    0.190   17.300  
coldlaunch.pss                    20.870    20.800    20.700    21.200    0.168   21.200  
coldlaunch.rss                    35.560    35.500    35.300    35.900    0.180   35.900  
```

This is in line with what @zbraniecki found when we added `getAdditionalLanguages` on master, so let's do it in v3 as well.