### PR TITLE
Delay mozApps.getAdditionalLanguages

### DIFF
--- a/src/bindings/html/service.js
+++ b/src/bindings/html/service.js
@@ -6,7 +6,7 @@ import { getMeta } from './head';
 import { negotiateLanguages } from './langs';
 
 export class Service {
-  constructor(fetch, additionalLangsAtLaunch) {
+  constructor(fetch) {
     let meta = getMeta(document.head);
     this.defaultLanguage = meta.defaultLang;
     this.availableLanguages = meta.availableLangs;
@@ -19,7 +19,7 @@ export class Service {
     ];
 
     changeLanguages.call(
-      this, additionalLangsAtLaunch, navigator.languages);
+      this, getAdditionalLanguages(), navigator.languages);
   }
 
   requestLanguages(requestedLangs = navigator.languages) {

--- a/src/runtime/web/index.js
+++ b/src/runtime/web/index.js
@@ -1,10 +1,9 @@
 'use strict';
 
 import { fetch } from './io';
-import { Service, getAdditionalLanguages } from '../../bindings/html/service';
+import { Service } from '../../bindings/html/service';
 import { setAttributes, getAttributes } from '../../bindings/html/dom';
 
-const additionalLangsAtLaunch = getAdditionalLanguages();
 const readyStates = {
   loading: 0,
   interactive: 1,
@@ -25,7 +24,7 @@ function whenInteractive(callback) {
 }
 
 function init() {
-  window.L10n = new Service(fetch, additionalLangsAtLaunch);
+  window.L10n = new Service(fetch);
   window.addEventListener('languagechange', window.L10n);
   document.addEventListener('additionallanguageschange', window.L10n);
 }


### PR DESCRIPTION
The numbers at https://l20n.etherpad.mozilla.org/v3-perf suggest that it would be beneficial to delay the `mozApps.getAdditionalLanguages` call after all.  Also, this is what master's l10n.js currently does as well, so we might want to keep the parity, at least for now.