### PR TITLE
Flatten the cache and remove _resMap

### DIFF
--- a/src/lib/context.js
+++ b/src/lib/context.js
@@ -25,10 +25,6 @@ export class Context {
       this._fallback.bind(this, Context.prototype._formatEntity, id, args));
   }
 
-  destroy() {
-    this._env.destroyContext(this);
-  }
-
   /* private */
 
   _formatTuple(args, entity) {
@@ -115,7 +111,7 @@ export class Context {
 
     // Look for `id` in every resource in order.
     for (var i = 0, resId; resId = this._resIds[i]; i++) {
-      var resource = cache[resId][lang.code][lang.src];
+      var resource = cache[resId + lang.code + lang.src];
       if (resource instanceof L10nError) {
         continue;
       }

--- a/tests/lib/env/resCache.js
+++ b/tests/lib/env/resCache.js
@@ -40,12 +40,15 @@ describe('Caching resources', function() {
   });
 
   it('caches resources', function() {
-    assert(env._resCache[res1]['en-US'].app);
-    assert(env._resCache[res2]['en-US'].app);
-    assert(env._resCache[res3]['en-US'].app instanceof L20n.L10nError);
+    assert(env._resCache[res1 + 'en-USapp']);
+    assert(env._resCache[res2 + 'en-USapp']);
+    assert(env._resCache[res3 + 'en-USapp'] instanceof L20n.L10nError);
   });
 
-  it('clears the cache only if no other ctx uses the resource', function() {
+  // destroyContext has been removed in PR #39
+  it.skip('clears the cache only if no other ctx uses the resource',
+    function() {
+
     env.destroyContext(ctx2);
     assert(env._resCache[res1]['en-US'].app);
     assert(!env._resCache[res2]);

--- a/tests/lib/env/resMap.js
+++ b/tests/lib/env/resMap.js
@@ -15,8 +15,8 @@ if (typeof navigator !== 'undefined') {
   var path = __dirname + '/..';
 }
 
-
-describe('Creating a context', function() {
+// resMap has been removed in PR #39
+describe.skip('Creating a context', function() {
   var env, ctx1, ctx2;
   var res1 = path + '/fixtures/basic.properties';
   var res2 = path + '/fixtures/en-US.properties';


### PR DESCRIPTION
In order to achieve parity with l10n.js, we could remove the destroy() method of `Context` and also simplify the cache storage by flattening its structure.  This wins us 50-80 KB of memory, according to my test.

We'll probably need a way to destroy contexts in the future, but right now it's safe to remove this feature.

Master (default, non-default):
```
Metric                            Mean     Median   Min      Max       StdDev  p95     
--------------------------------  -------  -------  -------  --------  ------  --------
coldlaunch.navigationLoaded       458.933  431.000  380.000  664.000   73.332  662.000 
coldlaunch.navigationInteractive  806.167  823.000  549.000  952.000   80.781  892.000 
coldlaunch.visuallyLoaded         806.333  823.000  550.000  952.000   80.735  893.000 
coldlaunch.contentInteractive     806.733  823.500  550.000  953.000   80.755  893.000 
coldlaunch.fullyLoaded            936.833  944.000  723.000  1091.000  70.787  1038.000
coldlaunch.uss                    10.347   10.300   10.100   10.600    0.112   10.500  
coldlaunch.pss                    14.663   14.600   14.500   14.800    0.087   14.800  
coldlaunch.rss                    29.010   29.000   28.800   29.200    0.083   29.200  

Metric                            Mean      Median    Min      Max       StdDev  p95     
--------------------------------  --------  --------  -------  --------  ------  --------
coldlaunch.navigationLoaded       466.300   455.500   419.000  622.000   45.584  582.000 
coldlaunch.navigationInteractive  979.733   977.500   799.000  1129.000  72.300  1122.000
coldlaunch.visuallyLoaded         980.100   978.000   800.000  1129.000  72.330  1122.000
coldlaunch.contentInteractive     980.300   978.500   800.000  1129.000  72.338  1122.000
coldlaunch.fullyLoaded            1127.367  1130.000  940.000  1308.000  74.828  1270.000
coldlaunch.pss                    16.673    16.700    16.500   16.800    0.073   16.700  
coldlaunch.rss                    31.060    31.100    30.900   31.200    0.080   31.100  
coldlaunch.uss                    12.323    12.300    12.100   12.500    0.092   12.400
````

Baseline v3 (default, non-default):
```
Metric                            Mean     Median   Min      Max       StdDev  p95     
--------------------------------  -------  -------  -------  --------  ------  --------
coldlaunch.navigationLoaded       444.000  435.500  399.000  578.000   39.095  562.000 
coldlaunch.navigationInteractive  824.133  822.000  692.000  965.000   63.226  940.000 
coldlaunch.visuallyLoaded         824.467  822.000  692.000  965.000   63.279  941.000 
coldlaunch.contentInteractive     824.567  822.000  692.000  965.000   63.221  941.000 
coldlaunch.fullyLoaded            954.533  957.500  845.000  1099.000  57.114  1084.000
coldlaunch.uss                    10.380   10.400   10.200   10.600    0.095   10.600  
coldlaunch.pss                    14.703   14.700   14.500   14.900    0.091   14.900  
coldlaunch.rss                    29.050   29.000   28.900   29.200    0.081   29.200  

Metric                            Mean      Median    Min      Max       StdDev  p95     
--------------------------------  --------  --------  -------  --------  ------  --------
coldlaunch.navigationLoaded       486.200   475.000   434.000  631.000   49.072  604.000 
coldlaunch.navigationInteractive  976.633   990.500   830.000  1138.000  75.340  1080.000
coldlaunch.visuallyLoaded         976.767   990.500   830.000  1138.000  75.301  1080.000
coldlaunch.contentInteractive     977.033   991.000   830.000  1138.000  75.328  1081.000
coldlaunch.fullyLoaded            1122.533  1134.000  984.000  1300.000  76.413  1245.000
coldlaunch.uss                    12.473    12.500    12.300   12.600    0.085   12.600  
coldlaunch.pss                    16.817    16.800    16.700   16.900    0.058   16.900  
coldlaunch.rss                    31.203    31.200    31.000   31.300    0.060   31.300  
```

v3 with this patch:
```
Metric                            Mean     Median   Min      Max       StdDev  p95     
--------------------------------  -------  -------  -------  --------  ------  --------
coldlaunch.navigationLoaded       450.400  439.500  398.000  610.000   45.299  560.000 
coldlaunch.navigationInteractive  815.867  833.500  655.000  931.000   70.583  899.000 
coldlaunch.visuallyLoaded         816.067  833.500  655.000  931.000   70.614  899.000 
coldlaunch.contentInteractive     816.333  834.000  655.000  932.000   70.710  899.000 
coldlaunch.fullyLoaded            951.800  960.500  812.000  1077.000  64.669  1035.000
coldlaunch.uss                    10.407   10.400   10.200   10.500    0.096   10.500  
coldlaunch.rss                    29.077   29.050   28.900   29.200    0.105   29.200  
coldlaunch.pss                    14.733   14.700   14.600   14.900    0.079   14.800  

Metric                            Mean      Median    Min      Max       StdDev  p95     
--------------------------------  --------  --------  -------  --------  ------  --------
coldlaunch.navigationLoaded       498.933   484.500   433.000  657.000   57.952  614.000 
coldlaunch.navigationInteractive  955.567   970.500   809.000  1126.000  89.124  1094.000
coldlaunch.visuallyLoaded         955.767   970.500   809.000  1126.000  89.104  1094.000
coldlaunch.contentInteractive     956.100   972.500   809.000  1126.000  89.056  1094.000
coldlaunch.fullyLoaded            1103.100  1114.500  956.000  1255.000  86.797  1239.000
coldlaunch.pss                    16.753    16.800    16.600   16.900    0.099   16.900  
coldlaunch.uss                    12.397    12.400    12.200   12.600    0.114   12.600  
coldlaunch.rss                    31.137    31.200    30.900   31.300    0.125   31.300 
```