### PR TITLE
Remove the meta WeakMap

### DIFF
--- a/tests/lib/resolver/attributes_test.js
+++ b/tests/lib/resolver/attributes_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import assert from 'assert';
-import { format, createEntries } from './header';
+import { format, lang, createEntries } from './header';
 import { MockContext } from './header';
 
 describe('Attributes', function(){
@@ -20,13 +20,13 @@ describe('Attributes', function(){
     });
 
     it('returns the value', function(){
-      var formatted = format(ctx, null, entries.foo.attrs.attr);
+      var formatted = format(ctx, lang, null, entries.foo.attrs.attr);
       assert.strictEqual(formatted[1], 'An attribute');
     });
 
     it('returns the value with a placeable', function(){
       var formatted = format(
-        ctx, null, entries.foo.attrs.attrComplex);
+        ctx, lang, null, entries.foo.attrs.attrComplex);
       assert.strictEqual(formatted[1], 'An attribute referencing Bar');
     });
 
@@ -44,12 +44,12 @@ describe('Attributes', function(){
     });
 
     it('returns the value of the entity', function(){
-      var formatted = format(ctx, null, entries.update);
+      var formatted = format(ctx, lang, null, entries.update);
       assert.strictEqual(formatted[1], 'Update');
     });
 
     it('returns the value of the attribute\'s member', function(){
-      var formatted = format(ctx, {n: 1}, entries.update.attrs.title);
+      var formatted = format(ctx, lang, {n: 1}, entries.update.attrs.title);
       assert.strictEqual(formatted[1], 'One update available');
     });
 
@@ -71,13 +71,13 @@ describe('Attributes', function(){
     });
 
     it('returns the value of the entity', function(){
-      var formatted = format(ctx, {n: 1, k: 2}, entries.update);
+      var formatted = format(ctx, lang, {n: 1, k: 2}, entries.update);
       assert.strictEqual(formatted[1], 'One update');
     });
 
     it('returns the value of the attribute', function(){
       var formatted = format(
-        ctx, {n: 1, k: 2}, entries.update.attrs.title);
+        ctx, lang, {n: 1, k: 2}, entries.update.attrs.title);
       assert.strictEqual(formatted[1], '2 updates title');
     });
 
@@ -94,12 +94,12 @@ describe('Attributes', function(){
     });
 
     it('returns the value of the entity', function(){
-      var value = format(ctx, null, entries.brandName)[1];
+      var value = format(ctx, lang, null, entries.brandName)[1];
       assert.strictEqual(value, 'Firefox');
     });
 
     it('returns the value of the attribute', function(){
-      var attr = format(ctx, null, entries.brandName.attrs.title)[1];
+      var attr = format(ctx, lang, null, entries.brandName.attrs.title)[1];
       assert.strictEqual(attr, 'Mozilla Firefox');
     });
 
@@ -116,7 +116,7 @@ describe('Attributes', function(){
     });
 
     it('returns the raw string of the attribute', function(){
-      var attr = format(ctx, null, entries.brandName.attrs.title)[1];
+      var attr = format(ctx, lang, null, entries.brandName.attrs.title)[1];
       assert.strictEqual(attr, 'Mozilla {{ brandName.title }}');
     });
 

--- a/tests/lib/resolver/ctxdata_test.js
+++ b/tests/lib/resolver/ctxdata_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import assert from 'assert';
-import { format, createEntries } from './header';
+import { format, lang, createEntries } from './header';
 import { MockContext } from './header';
 
 describe('Context data', function(){
@@ -26,17 +26,17 @@ describe('Context data', function(){
     });
 
     it('can be referenced from strings', function() {
-      var value = format(ctx, args, entries.unread)[1];
+      var value = format(ctx, lang, args, entries.unread)[1];
       assert.strictEqual(value, 'Unread notifications: 3');
     });
 
     it('can be passed as argument to a macro', function() {
-      var value = format(ctx, args, entries.unreadPlural)[1];
+      var value = format(ctx, lang, args, entries.unreadPlural)[1];
       assert.strictEqual(value, '3 unread notifications');
     });
 
     it('takes priority over entities of the same name', function() {
-      var value = format(ctx, args, entries.useFoo)[1];
+      var value = format(ctx, lang, args, entries.useFoo)[1];
       assert.strictEqual(value, 'Foo');
     });
 
@@ -63,39 +63,39 @@ describe('Context data', function(){
 
     it('returns the raw string when a missing property of args is ' +
        'referenced', function(){
-      var value = format(ctx, args, entries.missingReference)[1];
+      var value = format(ctx, lang, args, entries.missingReference)[1];
       assert.strictEqual(value, '{{ missing }}');
     });
 
     it('returns the raw string when an object is referenced', function(){
-      var value = format(ctx, args, entries.nestedReference)[1];
+      var value = format(ctx, lang, args, entries.nestedReference)[1];
       assert.strictEqual(value, '{{ nested }}');
     });
 
     it('returns the raw string when watch is referenced', function(){
-      var value = format(ctx, args, entries.watchReference)[1];
+      var value = format(ctx, lang, args, entries.watchReference)[1];
       assert.strictEqual(value, '{{ watch }}');
     });
 
     it('returns the raw string when hasOwnProperty is referenced', function(){
       var value = format(
-        ctx, args, entries.hasOwnPropertyReference)[1];
+        ctx, lang, args, entries.hasOwnPropertyReference)[1];
       assert.strictEqual(value, '{{ hasOwnProperty }}');
     });
 
     it('returns the raw string when isPrototypeOf is referenced', function(){
       var value = format(
-        ctx, args, entries.isPrototypeOfReference)[1];
+        ctx, lang, args, entries.isPrototypeOfReference)[1];
       assert.strictEqual(value, '{{ isPrototypeOf }}');
     });
 
     it('returns the raw string when toString is referenced', function(){
-      var value = format(ctx, args, entries.toStringReference)[1];
+      var value = format(ctx, lang, args, entries.toStringReference)[1];
       assert.strictEqual(value, '{{ toString }}');
     });
 
     it('returns the raw string when __proto__ is referenced', function(){
-      var value = format(ctx, args, entries.protoReference)[1];
+      var value = format(ctx, lang, args, entries.protoReference)[1];
       assert.strictEqual(value, '{{ __proto__ }}');
     });
 
@@ -121,23 +121,23 @@ describe('Context data', function(){
 
     it('returns a string value', function(){
       assert.strictEqual(
-        format(ctx, args, entries.stringProp)[1], 'string');
+        format(ctx, lang, args, entries.stringProp)[1], 'string');
     });
 
     it('throws when used in a macro', function(){
       assert.throws(function() {
-        format(ctx, args, entries.stringIndex);
+        format(ctx, lang, args, entries.stringIndex);
       }, 'Unresolvable value');
     });
 
     it('digit returns a string value', function(){
       assert.strictEqual(
-        format(ctx, args, entries.stringNumProp)[1], '1');
+        format(ctx, lang, args, entries.stringNumProp)[1], '1');
     });
 
     it('digit throws when used in a macro', function(){
       assert.throws(function() {
-        format(ctx, args, entries.stringNumIndex);
+        format(ctx, lang, args, entries.stringNumIndex);
       }, 'Unresolvable value');
     });
 
@@ -162,22 +162,22 @@ describe('Context data', function(){
     });
 
     it('returns a number value', function(){
-      assert.strictEqual(format(ctx, args, entries.numProp)[1], '1');
+      assert.strictEqual(format(ctx, lang, args, entries.numProp)[1], '1');
     });
 
     it('returns a value when used in macro', function(){
       assert.strictEqual(
-        format(ctx, args, entries.numIndex)[1], 'One');
+        format(ctx, lang, args, entries.numIndex)[1], 'One');
     });
 
     it('returns the raw string when NaN is referenced', function(){
-      var value = format(ctx, args, entries.nanProp)[1];
+      var value = format(ctx, lang, args, entries.nanProp)[1];
       assert.strictEqual(value, '{{ nan }}');
     });
 
     it('is undefined when NaN is used in macro', function(){
       assert.throws(function() {
-        format(ctx, args, entries.nanIndex);
+        format(ctx, lang, args, entries.nanIndex);
       }, 'Arg must be a string or a number: nan');
     });
 
@@ -198,13 +198,13 @@ describe('Context data', function(){
     });
 
     it('returns the raw string when referenced', function(){
-      var value = format(ctx, args, entries.boolProp)[1];
+      var value = format(ctx, lang, args, entries.boolProp)[1];
       assert.strictEqual(value, '{{ bool }}');
     });
 
     it('is undefined when used in a macro', function(){
       assert.throws(function() {
-        format(ctx, args, entries.boolIndex);
+        format(ctx, lang, args, entries.boolIndex);
       }, 'Arg must be a string or a number: bool');
     });
 
@@ -225,13 +225,13 @@ describe('Context data', function(){
     });
 
     it('returns the raw string when referenced', function(){
-      var value = format(ctx, args, entries.undefProp)[1];
+      var value = format(ctx, lang, args, entries.undefProp)[1];
       assert.strictEqual(value, '{{ undef }}');
     });
 
     it('is undefined when used in a macro', function(){
       assert.throws(function() {
-        format(ctx, args, entries.undefIndex);
+        format(ctx, lang, args, entries.undefIndex);
       }, 'Arg must be a string or a number: undef');
     });
 
@@ -252,13 +252,13 @@ describe('Context data', function(){
     });
 
     it('returns the raw string', function(){
-      var value = format(ctx, args, entries.nullProp)[1];
+      var value = format(ctx, lang, args, entries.nullProp)[1];
       assert.strictEqual(value, '{{ nullable }}');
     });
 
     it('is undefined when used in a macro', function(){
       assert.throws(function() {
-        format(ctx, args, entries.nullIndex);
+        format(ctx, lang, args, entries.nullIndex);
       }, 'Arg must be a string or a number: nullable');
     });
 
@@ -279,13 +279,13 @@ describe('Context data', function(){
     });
 
     it('returns the raw string', function(){
-      var value = format(ctx, args, entries.arrProp)[1];
+      var value = format(ctx, lang, args, entries.arrProp)[1];
       assert.strictEqual(value, '{{ arr }}');
     });
 
     it('is undefined when used in a macro', function(){
       assert.throws(function() {
-        format(ctx, args, entries.arrIndex);
+        format(ctx, lang, args, entries.arrIndex);
       }, 'Arg must be a string or a number: arr');
     });
 
@@ -306,13 +306,13 @@ describe('Context data', function(){
     });
 
     it('returns the raw string', function(){
-      var value = format(ctx, args, entries.arrProp)[1];
+      var value = format(ctx, lang, args, entries.arrProp)[1];
       assert.strictEqual(value, '{{ arr }}');
     });
 
     it('is undefined when used in a macro', function(){
       assert.throws(function() {
-        format(ctx, args, entries.arrIndex);
+        format(ctx, lang, args, entries.arrIndex);
       }, 'Arg must be a string or a number: arr');
     });
 
@@ -335,13 +335,13 @@ describe('Context data', function(){
     });
 
     it('returns the raw string', function(){
-      var value = format(ctx, args, entries.objProp)[1];
+      var value = format(ctx, lang, args, entries.objProp)[1];
       assert.strictEqual(value, '{{ obj }}');
     });
 
     it('throws used in a macro', function(){
       assert.throws(function() {
-        format(ctx, args, entries.objIndex);
+        format(ctx, lang, args, entries.objIndex);
       }, 'Arg must be a string or a number: obj');
     });
   });

--- a/tests/lib/resolver/dos_test.js
+++ b/tests/lib/resolver/dos_test.js
@@ -2,7 +2,7 @@
 'use strict';
 
 import assert from 'assert';
-import { format, createEntries } from './header';
+import { format, lang, createEntries } from './header';
 import { MockContext } from './header';
 
 // Bug 803931 - Compiler is vulnerable to the billion laughs attack
@@ -27,7 +27,7 @@ describe('Billion Laughs', function(){
 
   it('format() throws', function() {
     assert.throws(function() {
-      format(ctx, null, entries.lolz);
+      format(ctx, lang, null, entries.lolz);
     }, /too many characters in placeable/i);
   });
 });

--- a/tests/lib/resolver/errors_test.js
+++ b/tests/lib/resolver/errors_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import assert from 'assert';
-import { format, createEntries } from './header';
+import { format, lang, createEntries } from './header';
 import { MockContext } from './header';
 
 describe('Compiler errors:', function(){
@@ -21,7 +21,7 @@ describe('Compiler errors:', function(){
 
     it('works with the default index', function(){
       assert.strictEqual(
-        format(ctx, {n: 1}, entries.prompt)[1], 'One File');
+        format(ctx, lang, {n: 1}, entries.prompt)[1], 'One File');
     });
 
   });
@@ -38,7 +38,7 @@ describe('Compiler errors:', function(){
     });
 
     it('returns the raw string', function(){
-      var value = format(ctx, {n: 1}, entries.prompt)[1];
+      var value = format(ctx, lang, {n: 1}, entries.prompt)[1];
       assert.strictEqual(value, 'One {{ file }}');
     });
 
@@ -58,12 +58,12 @@ describe('Compiler errors:', function(){
 
     it('is found', function(){
       assert.strictEqual(
-        format(ctx, {n: 1}, entries.prompt)[1], 'One File');
+        format(ctx, lang, {n: 1}, entries.prompt)[1], 'One File');
     });
 
     it('throws an IndexError if n is not defined', function(){
       assert.throws(function() {
-        format(ctx, null, entries.prompt);
+        format(ctx, lang, null, entries.prompt);
       }, 'Unknown reference: n');
     });
 
@@ -82,12 +82,12 @@ describe('Compiler errors:', function(){
 
     it('is found', function(){
       assert.strictEqual(
-        format(ctx, {n: 1}, entries.prompt)[1], 'One File');
+        format(ctx, lang, {n: 1}, entries.prompt)[1], 'One File');
     });
 
     it('throws an IndexError if n is not defined', function(){
       assert.throws(function() {
-        format(ctx, null, entries.prompt);
+        format(ctx, lang, null, entries.prompt);
       }, 'Unknown reference: n');
     });
 

--- a/tests/lib/resolver/header.js
+++ b/tests/lib/resolver/header.js
@@ -6,16 +6,16 @@ import { getPluralRule } from '../../../src/lib/plurals';
 
 export { format } from '../../../src/lib/resolver';
 
+export const lang = {
+  code:'en-US',
+  src: 'app',
+  dir: 'ltr'
+};
+
 export function createEntries(source) {
   /* jshint -W089 */
   var entries = Object.create(null);
   var ast = PropertiesParser.parse(null, source);
-
-  var lang = {
-    code:'en-US',
-    src: 'app',
-    dir: 'ltr'
-  };
 
   for (var i = 0, len = ast.length; i < len; i++) {
     entries[ast[i].$i] = createEntry(ast[i], lang);

--- a/tests/lib/resolver/indexes_test.js
+++ b/tests/lib/resolver/indexes_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import assert from 'assert';
-import { format, createEntries } from './header';
+import { format, lang, createEntries } from './header';
 import { MockContext } from './header';
 
 describe('Index', function(){
@@ -23,16 +23,16 @@ describe('Index', function(){
     });
 
     it('works when the index is a regular entity', function() {
-      var value = format(ctx, {n: 1}, entries.indexEntity)[1];
+      var value = format(ctx, lang, {n: 1}, entries.indexEntity)[1];
       assert.strictEqual(value, 'One entity');
     });
     it('throws when the index is an uncalled macro', function() {
       assert.throws(function() {
-        format(ctx, {n: 1}, entries.indexUncalledMacro);
+        format(ctx, lang, {n: 1}, entries.indexUncalledMacro);
       }, 'Unresolvable value');
     });
     it('works when the index is a called macro', function() {
-      var value = format(ctx, {n: 1}, entries.indexCalledMacro)[1];
+      var value = format(ctx, lang, {n: 1}, entries.indexCalledMacro)[1];
       assert.strictEqual(value, 'One called macro');
     });
 
@@ -50,7 +50,7 @@ describe('Index', function(){
 
     it('is undefined', function() {
       assert.throws(function() {
-        format(ctx, null, entries.foo);
+        format(ctx, lang, null, entries.foo);
       }, 'Cyclic reference detected: foo');
     });
 
@@ -69,9 +69,9 @@ describe('Index', function(){
     });
 
     it('value of the attribute is undefined', function() {
-      assert.strictEqual(format(ctx, null, entries.foo)[1], 'Foo');
+      assert.strictEqual(format(ctx, lang, null, entries.foo)[1], 'Foo');
       assert.throws(function() {
-        format(ctx, null, entries.foo.attrs.attr);
+        format(ctx, lang, null, entries.foo.attrs.attr);
       }, 'Unresolvable value');
     });
 

--- a/tests/lib/resolver/macros_test.js
+++ b/tests/lib/resolver/macros_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import assert from 'assert';
-import { format, createEntries } from './header';
+import { format, lang, createEntries } from './header';
 import { MockContext } from './header';
 
 describe('Macros', function(){
@@ -23,10 +23,10 @@ describe('Macros', function(){
     it('throws when resolving (not calling) a macro in a complex ' +
        'string', function() {
       assert.strictEqual(
-        format(ctx, args, entries.placeMacro)[1], '{{ plural }}');
+        format(ctx, lang, args, entries.placeMacro)[1], '{{ plural }}');
       assert.strictEqual(
         format(
-          ctx, args, entries.placeRealMacro)[1], '{{ __plural }}');
+          ctx, lang, args, entries.placeRealMacro)[1], '{{ __plural }}');
     });
 
   });
@@ -67,37 +67,37 @@ describe('Macros', function(){
 
     it('throws if an entity is passed', function() {
       assert.throws(function() {
-        format(ctx, args, entries.passFoo);
+        format(ctx, lang, args, entries.passFoo);
       }, 'Unresolvable value');
     });
 
     it('throws if a complex entity is passed', function() {
       assert.throws(function() {
-        format(ctx, args, entries.passUseFoo);
+        format(ctx, lang, args, entries.passUseFoo);
       }, 'Unresolvable value');
     });
 
     it('throws if a hash entity is passed', function() {
       assert.throws(function() {
-        format(ctx, args, entries.passBar);
+        format(ctx, lang, args, entries.passBar);
       }, 'Unresolvable value');
     });
 
     it('throws if a macro is passed', function() {
       assert.throws(function() {
-        format(ctx, args, entries.passPlural);
+        format(ctx, lang, args, entries.passPlural);
       }, 'Unresolvable value');
     });
 
     it('throws if a missing entry is passed', function() {
       assert.throws(function() {
-        format(ctx, args, entries.passMissing);
+        format(ctx, lang, args, entries.passMissing);
       }, 'Unknown reference: missing');
     });
 
     it('throws if a native function is passed', function() {
       assert.throws(function() {
-        format(ctx, args, entries.passWatch);
+        format(ctx, lang, args, entries.passWatch);
       }, 'Unknown reference: watch');
     });
 
@@ -127,28 +127,28 @@ describe('A simple plural macro', function(){
   });
 
   it('returns zero for 0', function() {
-    var value = format(ctx, {n: 0}, entries.foo)[1];
+    var value = format(ctx, lang, {n: 0}, entries.foo)[1];
     assert.strictEqual(value, 'Zero');
   });
 
   it('returns one for 1', function() {
-    var value = format(ctx, {n: 1}, entries.foo)[1];
+    var value = format(ctx, lang, {n: 1}, entries.foo)[1];
     assert.strictEqual(value, 'One');
   });
 
   it('returns two for 2', function() {
-    var value = format(ctx, {n: 2}, entries.foo)[1];
+    var value = format(ctx, lang, {n: 2}, entries.foo)[1];
     assert.strictEqual(value, 'Two');
   });
 
   it('returns other for 3', function() {
-    var value = format(ctx, {n: 3}, entries.foo)[1];
+    var value = format(ctx, lang, {n: 3}, entries.foo)[1];
     assert.strictEqual(value, 'Other');
   });
 
   it('throws for no arg', function() {
     assert.throws(function() {
-      format(ctx, null, entries.foo);
+      format(ctx, lang, null, entries.foo);
     }, 'Unknown reference: n');
   });
 
@@ -182,38 +182,38 @@ describe('A more complex plural macro', function(){
     });
 
     it('returns zero for 0', function() {
-      var value = format(ctx, {n: 0}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 0}, entries.foo)[1];
       assert.strictEqual(value, 'Zero');
     });
 
     it('returns one for 1', function() {
-      var value = format(ctx, {n: 1}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 1}, entries.foo)[1];
       assert.strictEqual(value, 'One');
     });
 
     it('returns two for 2', function() {
-      var value = format(ctx, {n: 2}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 2}, entries.foo)[1];
       assert.strictEqual(value, 'Two');
     });
 
     it('returns many for 3', function() {
-      var value = format(ctx, {n: 3}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 3}, entries.foo)[1];
       assert.strictEqual(value, 'Many');
     });
 
     it('returns many for 5', function() {
-      var value = format(ctx, {n: 5}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 5}, entries.foo)[1];
       assert.strictEqual(value, 'Many');
     });
 
     it('returns other for 0.5', function() {
-      var value = format(ctx, {n: 0.5}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 0.5}, entries.foo)[1];
       assert.strictEqual(value, 'Other');
     });
 
     it('throws for no arg', function() {
       assert.throws(function() {
-        format(ctx, null, entries.foo);
+        format(ctx, lang, null, entries.foo);
       }, 'Unknown reference: n');
     });
 
@@ -232,32 +232,32 @@ describe('A more complex plural macro', function(){
     });
 
     it('returns other for 0', function() {
-      var value = format(ctx, {n: 0}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 0}, entries.foo)[1];
       assert.strictEqual(value, 'Other');
     });
 
     it('returns many for 1', function() {
-      var value = format(ctx, {n: 1}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 1}, entries.foo)[1];
       assert.strictEqual(value, 'Many');
     });
 
     it('returns many for 2', function() {
-      var value = format(ctx, {n: 2}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 2}, entries.foo)[1];
       assert.strictEqual(value, 'Many');
     });
 
     it('returns many for 3', function() {
-      var value = format(ctx, {n: 3}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 3}, entries.foo)[1];
       assert.strictEqual(value, 'Many');
     });
 
     it('returns many for 5', function() {
-      var value = format(ctx, {n: 5}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 5}, entries.foo)[1];
       assert.strictEqual(value, 'Many');
     });
 
     it('returns other for 0.5', function() {
-      var value = format(ctx, {n: 0.5}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 0.5}, entries.foo)[1];
       assert.strictEqual(value, 'Other');
     });
 
@@ -275,32 +275,32 @@ describe('A more complex plural macro', function(){
     });
 
     it('returns other for 0', function() {
-      var value = format(ctx, {n: 0}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 0}, entries.foo)[1];
       assert.strictEqual(value, 'Other');
     });
 
     it('returns other for 1', function() {
-      var value = format(ctx, {n: 1}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 1}, entries.foo)[1];
       assert.strictEqual(value, 'Other');
     });
 
     it('returns other for 2', function() {
-      var value = format(ctx, {n: 2}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 2}, entries.foo)[1];
       assert.strictEqual(value, 'Other');
     });
 
     it('returns other for 3', function() {
-      var value = format(ctx, {n: 3}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 3}, entries.foo)[1];
       assert.strictEqual(value, 'Other');
     });
 
     it('returns other for 5', function() {
-      var value = format(ctx, {n: 5}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 5}, entries.foo)[1];
       assert.strictEqual(value, 'Other');
     });
 
     it('returns other for 0.5', function() {
-      var value = format(ctx, {n: 0.5}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 0.5}, entries.foo)[1];
       assert.strictEqual(value, 'Other');
     });
 
@@ -320,36 +320,36 @@ describe('A more complex plural macro', function(){
 
     it('throws for 0', function() {
       assert.throws(function() {
-        format(ctx, {n: 0}, entries.foo);
+        format(ctx, lang, {n: 0}, entries.foo);
       }, 'Unresolvable value');
     });
 
     it('returns one for 1', function() {
-      var value = format(ctx, {n: 1}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 1}, entries.foo)[1];
       assert.strictEqual(value, 'One');
     });
 
     it('throws for 2', function() {
       assert.throws(function() {
-        format(ctx, {n: 2}, entries.foo);
+        format(ctx, lang, {n: 2}, entries.foo);
       }, 'Unresolvable value');
     });
 
     it('throws for 3', function() {
       assert.throws(function() {
-        format(ctx, {n: 3}, entries.foo);
+        format(ctx, lang, {n: 3}, entries.foo);
       }, 'Unresolvable value');
     });
 
     it('throws for 5', function() {
       assert.throws(function() {
-        format(ctx, {n: 5}, entries.foo);
+        format(ctx, lang, {n: 5}, entries.foo);
       }, 'Unresolvable value');
     });
 
     it('throws for 0.5', function() {
       assert.throws(function() {
-        format(ctx, {n: 0.5}, entries.foo);
+        format(ctx, lang, {n: 0.5}, entries.foo);
       }, 'Unresolvable value');
     });
 

--- a/tests/lib/resolver/primitives_test.js
+++ b/tests/lib/resolver/primitives_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import assert from 'assert';
-import { format, createEntries } from './header';
+import { format, lang, createEntries } from './header';
 import { MockContext } from './header';
 
 describe('Primitives:', function(){
@@ -17,7 +17,7 @@ describe('Primitives:', function(){
     });
 
     it('returns the value', function(){
-      assert.strictEqual(format(ctx, null, entries.foo)[1], 'Foo');
+      assert.strictEqual(format(ctx, lang, null, entries.foo)[1], 'Foo');
     });
 
   });
@@ -35,13 +35,13 @@ describe('Primitives:', function(){
     });
 
     it('returns the value', function(){
-      var value = format(ctx, null, entries.bar)[1];
+      var value = format(ctx, lang, null, entries.bar)[1];
       assert.strictEqual(value, 'Foo Bar');
     });
 
     it('returns the raw string if the referenced entity is ' +
        'not found', function(){
-      var value = format(ctx, null, entries.baz)[1];
+      var value = format(ctx, lang, null, entries.baz)[1];
       assert.strictEqual(value, '{{ missing }}');
     });
 
@@ -58,18 +58,18 @@ describe('Primitives:', function(){
     });
 
     it('returns the null value', function(){
-      var value = format(ctx, null, entries.foo)[1];
+      var value = format(ctx, lang, null, entries.foo)[1];
       assert.strictEqual(value, null);
     });
 
     it('returns the attribute', function(){
-      var attr = format(ctx, null, entries.foo.attrs.attr)[1];
+      var attr = format(ctx, lang, null, entries.foo.attrs.attr)[1];
       assert.strictEqual(attr, 'Foo');
     });
 
     it('returns the raw string when the referenced entity has ' +
        'null value', function(){
-      var value = format(ctx, null, entries.bar)[1];
+      var value = format(ctx, lang, null, entries.bar)[1];
       assert.strictEqual(value, '{{ foo }} Bar');
     });
 
@@ -86,7 +86,7 @@ describe('Primitives:', function(){
     });
 
     it('returns the raw string', function(){
-      var value = format(ctx, null, entries.foo)[1];
+      var value = format(ctx, lang, null, entries.foo)[1];
       assert.strictEqual(value, '{{ foo }}');
     });
 
@@ -102,7 +102,7 @@ describe('Primitives:', function(){
     });
 
     it('returns the raw string', function(){
-      var value = format(ctx, null, entries.foo)[1];
+      var value = format(ctx, lang, null, entries.foo)[1];
       assert.strictEqual(value, '{{ foo }}');
     });
 
@@ -121,12 +121,12 @@ describe('Primitives:', function(){
     });
 
     it('returns the raw string', function(){
-      var value = format(ctx, {n: 1}, entries.foo)[1];
+      var value = format(ctx, lang, {n: 1}, entries.foo)[1];
       assert.strictEqual(value, '{{ foo }}');
     });
 
     it('returns the valid value if requested directly', function(){
-      var value = format(ctx, {n: 2}, entries.bar)[1];
+      var value = format(ctx, lang, {n: 2}, entries.bar)[1];
       assert.strictEqual(value, 'Bar');
     });
   });


### PR DESCRIPTION
I was reviewing #42 and I realized that we don't actually need to store the `id` and `lang` for each entity.  The `id` is needed for the error recovery which can be (and even should be) done in the context, and `lang` is needed for getting the right values for placeables and macros, but it should be constant during a single formatting operation.

I decided to go ahead and suggest this change.  @zbraniecki, I can help you rebase #42 on top of this, I'm expecting some (but not many) conflicts.