### PR TITLE
Move resolutionChain into locals

### DIFF
--- a/src/bindings/gaiabuild/view.js
+++ b/src/bindings/gaiabuild/view.js
@@ -50,8 +50,8 @@ export class View {
     }
   }
 
-  observe() {}
-  disconnect() {}
+  _observe() {}
+  _disconnect() {}
 
   _resolveEntities(langs, keys) {
     return this.ctx.resolveEntities(langs, keys);

--- a/src/bindings/html/dom.js
+++ b/src/bindings/html/dom.js
@@ -88,9 +88,9 @@ function translateElements(view, langs, elements) {
 }
 
 function applyTranslations(view, elems, translations) {
-  view.disconnect();
+  view._disconnect();
   for (let i = 0; i < elems.length; i++) {
     overlayElement(elems[i], translations[i]);
   }
-  view.observe();
+  view._observe();
 }

--- a/src/bindings/html/view.js
+++ b/src/bindings/html/view.js
@@ -16,10 +16,10 @@ const observerConfig = {
 
 export class View {
   constructor(client, doc) {
-    this.doc = doc;
+    this._doc = doc;
     this.qps = qps;
 
-    this.interactive = documentReady().then(
+    this._interactive = documentReady().then(
       () => init(this, client));
 
     this.ready = new Promise(function(resolve) {
@@ -31,36 +31,36 @@ export class View {
     });
 
     const observer = new MutationObserver(onMutations.bind(this));
-    this.observe = () => observer.observe(this.doc, observerConfig);
-    this.disconnect = () => observer.disconnect();
+    this._observe = () => observer.observe(doc, observerConfig);
+    this._disconnect = () => observer.disconnect();
 
     this.resolvedLanguages().then(
       langs => translateDocument(this, langs));
   }
 
   resolvedLanguages() {
-    return this.interactive.then(
+    return this._interactive.then(
       client => client.languages);
   }
 
   requestLanguages(langs) {
-    return this.interactive.then(
+    return this._interactive.then(
       client => client.requestLanguages(langs));
   }
 
   _resolveEntities(langs, keys) {
-    return this.interactive.then(
+    return this._interactive.then(
       client => client.resolveEntities(this, langs, keys));
   }
 
   formatValue(id, args) {
-    return this.interactive.then(
+    return this._interactive.then(
       client => client.formatValues(this, [[id, args]])).then(
         values => values[0]);
   }
 
   formatValues(...keys) {
-    return this.interactive.then(
+    return this._interactive.then(
       client => client.formatValues(this, keys));
   }
 
@@ -74,8 +74,8 @@ View.prototype.setAttributes = setAttributes;
 View.prototype.getAttributes = getAttributes;
 
 function init(view, client) {
-  view.observe();
-  return client.registerView(view, getResourceLinks(view.doc.head)).then(
+  view._observe();
+  return client.registerView(view, getResourceLinks(view._doc.head)).then(
     () => client);
 }
 
@@ -85,7 +85,7 @@ function onMutations(mutations) {
 }
 
 export function translateDocument(view, langs) {
-  const doc = view.doc;
+  const doc = view._doc;
 
   if (langs[0].code === doc.documentElement.getAttribute('lang')) {
     return Promise.resolve().then(


### PR DESCRIPTION
By moving the resolution chain into locals we're reducing the complexity in `format`: we can get rid of one `try...finally`.  Since we're creating a new WeakSet with every `format` call, this is a tiny tiny bit slower:  `grunt perf` reports 300 microseconds slower, or 12%.