### PR TITLE
Pass an emitter function to parsers

### DIFF
--- a/src/bindings/gaiabuild/view.js
+++ b/src/bindings/gaiabuild/view.js
@@ -25,8 +25,7 @@ export class View {
     // stop the build if these errors happen for en-US
     // XXX tv_apps break the build https://bugzil.la/1179833
     // this.env.addEventListener('fetcherror', stop);
-    // XXX parse errors don't have the lang property needed by stopBuild
-    // this.env.addEventListener('parseerror', stop);
+    this.env.addEventListener('parseerror', stop);
     this.env.addEventListener('duplicateerror', stop);
     this.env.addEventListener('notfounderror', stop);
     // XXX sms breaks the build https://bugzil.la/1178187
@@ -99,7 +98,7 @@ export class View {
 }
 
 function amendError(err) {
-  err.message = err.message + ' in ' + this.htmloptimizer.webapp.url;
+  err.message = err.message + ' (' + this.htmloptimizer.webapp.url + ')';
 }
 
 function logError(err) {

--- a/src/lib/format/l20n/parser.js
+++ b/src/lib/format/l20n/parser.js
@@ -15,7 +15,7 @@ export default {
     };
   },
 
-  parse: function (env, string, simple) {
+  parse: function (emit, string, simple) {
     if (!this._patterns) {
       this.init();
     }
@@ -23,7 +23,7 @@ export default {
     this._index = 0;
     this._length = this._source.length;
     this.simpleMode = simple;
-    this.env = env;
+    this.emit = emit;
 
     return this.getL20n();
   },
@@ -310,8 +310,8 @@ export default {
           ast.push(entry);
         }
       } catch (e) {
-        if (this.env) {
-          this.env.emit('parseerror', e);
+        if (this.emit) {
+          this.emit('parseerror', e);
         } else {
           throw e;
         }

--- a/src/lib/format/properties/parser.js
+++ b/src/lib/format/properties/parser.js
@@ -21,7 +21,7 @@ export default {
     };
   },
 
-  parse: function(env, source) {
+  parse: function(emit, source) {
     if (!this.patterns) {
       this.init();
     }
@@ -49,8 +49,8 @@ export default {
         try {
           this.parseEntity(entityMatch[1], entityMatch[2], ast);
         } catch (e) {
-          if (env) {
-            env.emit('parseerror', e);
+          if (emit) {
+            emit('parseerror', e);
           } else {
             throw e;
           }


### PR DESCRIPTION
We only need to pass the `env` into `parse` because of error emitting.  Let's just pass the emitter function instead, which gives us greater flexibility in terms of what that function actually is.  E.g. we can add meta data to emitted errors which is not available inside of the parser (like the current `lang`).