### PR TITLE
Support the legacy AST in the resolver

### DIFF
--- a/src/bindings/gaiabuild/legacy/context.js
+++ b/src/bindings/gaiabuild/legacy/context.js
@@ -1,0 +1,21 @@
+'use strict';
+
+import { Context } from '../../../lib/context';
+import { format } from './resolver';
+
+export function LegacyContext(env, resIds) {
+  Context.call(this, env, resIds);
+}
+
+LegacyContext.prototype = Object.create(Context.prototype);
+
+LegacyContext.prototype._formatTuple = function(lang, args, entity, id, key) {
+  try {
+    return format(this, lang, args, entity);
+  } catch (err) {
+    err.id = key ? id + '::' + key : id;
+    err.lang = lang;
+    this._env.emit('resolveerror', err, this);
+    return [{ error: err }, err.id];
+  }
+};

--- a/src/bindings/gaiabuild/legacy/env.js
+++ b/src/bindings/gaiabuild/legacy/env.js
@@ -2,62 +2,45 @@
 
 import { L10nError } from '../../../lib/errors';
 import { Env, amendError } from '../../../lib/env';
+import { LegacyContext } from './context';
 import { createEntry } from './resolver';
 import PropertiesParser from './parser';
 import { walkContent } from './pseudo';
 import { qps } from '../../../lib/pseudo';
-import {
-  emit, addEventListener, removeEventListener
-} from '../../../lib/events';
 
-// XXX babel transpiles class inheritance to code which modifies prototypes 
-// which triggers warnings in Gecko;  we redefine LegacyEnv from scratch to 
-// avoid warnings.
-export class LegacyEnv {
-  constructor(defaultLang, fetch) {
-    // XXX babel doesn't allow calling the constructor as a regular function 
-    // so we need to copy the whole constructor from Env
-    this.defaultLang = defaultLang;
-    this.fetch = fetch;
-
-    this._resCache = Object.create(null);
-
-    const listeners = {};
-    this.emit = emit.bind(this, listeners);
-    this.addEventListener = addEventListener.bind(this, listeners);
-    this.removeEventListener = removeEventListener.bind(this, listeners);
-  }
-
-  createContext(resIds) {
-    return Env.prototype.createContext.call(this, resIds);
-  }
-
-  _parse(syntax, lang, data) {
-    const emit = (type, err) => this.emit(type, amendError(lang, err));
-    return PropertiesParser.parse.call(PropertiesParser, emit, data);
-  }
-
-  _create(lang, ast) {
-    const entries = Object.create(null);
-    const create = lang.src === 'qps' ?
-      createPseudoEntry : createEntry;
-
-    for (let i = 0, node; node = ast[i]; i++) {
-      const id = node.$i;
-      if (id in entries) {
-        this.emit('duplicateerror', new L10nError(
-         'Duplicate string "' + id + '" found in ' + lang.code, id, lang));
-      }
-      entries[id] = create(node, lang);
-    }
-
-    return entries;
-  }
-
-  _getResource(lang, res) {
-    return Env.prototype._getResource.call(this, lang, res);
-  }
+// XXX babel's inheritance code triggers JavaScript warnings about modifying 
+// the prototype object so we use regular prototypal inheritance here
+export function LegacyEnv(defaultLang, fetch) {
+  Env.call(this, defaultLang, fetch);
 }
+
+LegacyEnv.prototype = Object.create(Env.prototype);
+
+LegacyEnv.prototype.createContext = function(resIds) {
+  return new LegacyContext(this, resIds);
+};
+
+LegacyEnv.prototype._parse = function(syntax, lang, data) {
+  const emit = (type, err) => this.emit(type, amendError(lang, err));
+  return PropertiesParser.parse.call(PropertiesParser, emit, data);
+};
+
+LegacyEnv.prototype._create = function(lang, ast) {
+  const entries = Object.create(null);
+  const create = lang.src === 'qps' ?
+    createPseudoEntry : createEntry;
+
+  for (let i = 0, node; node = ast[i]; i++) {
+    const id = node.$i;
+    if (id in entries) {
+      this.emit('duplicateerror', new L10nError(
+       'Duplicate string "' + id + '" found in ' + lang.code, id, lang));
+    }
+    entries[id] = create(node, lang);
+  }
+
+  return entries;
+};
 
 function createPseudoEntry(node, lang) {
   return createEntry(walkContent(node, qps[lang.code].translate));

--- a/src/bindings/gaiabuild/legacy/resolver.js
+++ b/src/bindings/gaiabuild/legacy/resolver.js
@@ -1,5 +1,19 @@
 'use strict';
 
+import { L10nError } from '../../../lib/errors';
+
+const KNOWN_MACROS = ['plural'];
+const MAX_PLACEABLE_LENGTH = 2500;
+
+// Matches characters outside of the Latin-1 character set
+const nonLatin1 = /[^\x01-\xFF]/;
+
+// Unicode bidi isolation characters
+const FSI = '\u2068';
+const PDI = '\u2069';
+
+const resolutionChain = new WeakSet();
+
 export function createEntry(node) {
   const keys = Object.keys(node);
 
@@ -38,4 +52,168 @@ function createAttribute(node) {
     value: node.$v || (node !== undefined ? node : null),
     index: node.$x || null,
   };
+}
+
+
+export function format(ctx, lang, args, entity) {
+  if (typeof entity === 'string') {
+    return [{}, entity];
+  }
+
+  if (resolutionChain.has(entity)) {
+    throw new L10nError('Cyclic reference detected');
+  }
+
+  resolutionChain.add(entity);
+
+  let rv;
+  // if format fails, we want the exception to bubble up and stop the whole
+  // resolving process;  however, we still need to remove the entity from the
+  // resolution chain
+  try {
+    rv = resolveValue(
+      {}, ctx, lang, args, entity.value, entity.index);
+  } finally {
+    resolutionChain.delete(entity);
+  }
+  return rv;
+}
+
+function resolveIdentifier(ctx, lang, args, id) {
+  if (KNOWN_MACROS.indexOf(id) > -1) {
+    return [{}, ctx._getMacro(lang, id)];
+  }
+
+  if (args && args.hasOwnProperty(id)) {
+    if (typeof args[id] === 'string' || (typeof args[id] === 'number' &&
+        !isNaN(args[id]))) {
+      return [{}, args[id]];
+    } else {
+      throw new L10nError('Arg must be a string or a number: ' + id);
+    }
+  }
+
+  // XXX: special case for Node.js where still:
+  // '__proto__' in Object.create(null) => true
+  if (id === '__proto__') {
+    throw new L10nError('Illegal id: ' + id);
+  }
+
+  const entity = ctx._getEntity(lang, id);
+
+  if (entity) {
+    return format(ctx, lang, args, entity);
+  }
+
+  throw new L10nError('Unknown reference: ' + id);
+}
+
+function subPlaceable(locals, ctx, lang, args, id) {
+  let res;
+
+  try {
+    res = resolveIdentifier(ctx, lang, args, id);
+  } catch (err) {
+    return [{ error: err }, '{{ ' + id + ' }}'];
+  }
+
+  const value = res[1];
+
+  if (typeof value === 'number') {
+    return res;
+  }
+
+  if (typeof value === 'string') {
+    // prevent Billion Laughs attacks
+    if (value.length >= MAX_PLACEABLE_LENGTH) {
+      throw new L10nError('Too many characters in placeable (' +
+                          value.length + ', max allowed is ' +
+                          MAX_PLACEABLE_LENGTH + ')');
+    }
+
+    if (locals.contextIsNonLatin1 || value.match(nonLatin1)) {
+      // When dealing with non-Latin-1 text
+      // we wrap substitutions in bidi isolate characters
+      // to avoid bidi issues.
+      res[1] = FSI + value + PDI;
+    }
+
+    return res;
+  }
+
+  return [{}, '{{ ' + id + ' }}'];
+}
+
+function interpolate(locals, ctx, lang, args, arr) {
+  return arr.reduce(function([localsSeq, valueSeq], cur) {
+    if (typeof cur === 'string') {
+      return [localsSeq, valueSeq + cur];
+    } else if (cur.t === 'idOrVar'){
+      const [, value] = subPlaceable(locals, ctx, lang, args, cur.v);
+      return [localsSeq, valueSeq + value];
+    }
+  }, [locals, '']);
+}
+
+function resolveSelector(ctx, lang, args, expr, index) {
+    const selectorName = index[0].v;
+    const selector = resolveIdentifier(ctx, lang, args, selectorName)[1];
+
+    if (typeof selector !== 'function') {
+      // selector is a simple reference to an entity or args
+      return selector;
+    }
+
+    const argValue = index[1] ?
+      resolveIdentifier(ctx, lang, args, index[1])[1] : undefined;
+
+    if (selectorName === 'plural') {
+      // special cases for zero, one, two if they are defined on the hash
+      if (argValue === 0 && 'zero' in expr) {
+        return 'zero';
+      }
+      if (argValue === 1 && 'one' in expr) {
+        return 'one';
+      }
+      if (argValue === 2 && 'two' in expr) {
+        return 'two';
+      }
+    }
+
+    return selector(argValue);
+}
+
+function resolveValue(locals, ctx, lang, args, expr, index) {
+  if (!expr) {
+    return [locals, expr];
+  }
+
+  if (typeof expr === 'string' ||
+      typeof expr === 'boolean' ||
+      typeof expr === 'number') {
+    return [locals, expr];
+  }
+
+  if (Array.isArray(expr)) {
+    locals.contextIsNonLatin1 = expr.some(function($_) {
+      return typeof($_) === 'string' && $_.match(nonLatin1);
+    });
+    return interpolate(locals, ctx, lang, args, expr);
+  }
+
+  // otherwise, it's a dict
+  if (index) {
+    // try to use the index in order to select the right dict member
+    const selector = resolveSelector(ctx, lang, args, expr, index);
+    if (expr.hasOwnProperty(selector)) {
+      return resolveValue(locals, ctx, lang, args, expr[selector]);
+    }
+  }
+
+  // if there was no index or no selector was found, try 'other'
+  if ('other' in expr) {
+    return resolveValue(locals, ctx, lang, args, expr.other);
+  }
+
+  throw new L10nError('Unresolvable value');
 }


### PR DESCRIPTION
@zbraniecki, I think we missed one thing when we landed the runtime parser:  the resolver needs to support both modes :(

This PR is based on https://github.com/l20n/l20n.js/commit/56bdee68c0eed0c9101db0bcede1596ca07032be#diff-36c4e7c2ec7b3cb60316760123cc81e9.