### PR TITLE
Move fetch out of format* methods in Context

### DIFF
--- a/src/bindings/html/view.js
+++ b/src/bindings/html/view.js
@@ -48,16 +48,19 @@ export class View {
 
   formatValue(id, args) {
     return this.service.languages.then(
+      langs => this.ctx.fetch(langs)).then(
       langs => this.ctx.formatValue(langs, id, args));
   }
 
   formatEntity(id, args) {
     return this.service.languages.then(
+      langs => this.ctx.fetch(langs)).then(
       langs => this.ctx.formatEntity(langs, id, args));
   }
 
   translateFragment(frag) {
     return this.service.languages.then(
+      langs => this.ctx.fetch(langs)).then(
       langs => translateFragment(this, langs, frag));
   }
 }

--- a/tests/lib/context/basic_test.js
+++ b/tests/lib/context/basic_test.js
@@ -13,9 +13,10 @@ const langs = [
 describe('A simple context with one resource', function() {
   var env, ctx;
 
-  beforeEach(function() {
+  beforeEach(function(done) {
     env = new Env('en-US', fetch);
     ctx = env.createContext([path + '/fixtures/basic.properties']);
+    ctx.fetch(langs).then(() => done(), done);
   });
 
   it('should return the string value of brandName', function(done) {

--- a/tests/lib/context/format_test.js
+++ b/tests/lib/context/format_test.js
@@ -19,9 +19,10 @@ function assertPromise(promise, expected, done) {
 describe('One fallback locale', function() {
   var env, ctx;
 
-  beforeEach(function() {
+  beforeEach(function(done) {
     env = new Env('en-US', fetch);
     ctx = env.createContext([path + '/fixtures/{locale}.properties']);
+    ctx.fetch(langs).then(() => done(), done);
   });
 
   describe('Translation in the first locale exists and is OK', function() {


### PR DESCRIPTION
We can optimize for the most common scenario by prefetching the resources for the first languages once instead of running the same logic on every `formatValue` or `formatEntity` call.