### PR TITLE
Remove formatValue

### DIFF
--- a/src/bindings/html/dom.js
+++ b/src/bindings/html/dom.js
@@ -111,7 +111,7 @@ function getElementTranslation(view, langs, elem) {
   const l10n = getAttributes(elem);
 
   return l10n.id ?
-    view.ctx.formatEntity(langs, l10n.id, l10n.args) : false;
+    view.ctx.resolve(langs, l10n.id, l10n.args) : false;
 }
 
 export function translateElement(view, langs, elem) {

--- a/src/bindings/html/view.js
+++ b/src/bindings/html/view.js
@@ -48,16 +48,19 @@ export class View {
 
   formatValue(id, args) {
     return this.service.languages.then(
+      langs => this.ctx.fetch(langs)).then(
       langs => this.ctx.formatValue(langs, id, args));
   }
 
   formatEntity(id, args) {
     return this.service.languages.then(
+      langs => this.ctx.fetch(langs)).then(
       langs => this.ctx.formatEntity(langs, id, args));
   }
 
   translateFragment(frag) {
     return this.service.languages.then(
+      langs => this.ctx.fetch(langs)).then(
       langs => translateFragment(this, langs, frag));
   }
 }

--- a/src/bindings/html/view.js
+++ b/src/bindings/html/view.js
@@ -46,16 +46,10 @@ export class View {
     return this.service.env.emit(...args);
   }
 
-  formatValue(id, args) {
+  format(id, args) {
     return this.service.languages.then(
       langs => this.ctx.fetch(langs)).then(
-      langs => this.ctx.formatValue(langs, id, args));
-  }
-
-  formatEntity(id, args) {
-    return this.service.languages.then(
-      langs => this.ctx.fetch(langs)).then(
-      langs => this.ctx.formatEntity(langs, id, args));
+      langs => this.ctx.resolve(langs, id, args));
   }
 
   translateFragment(frag) {

--- a/tests/lib/context/basic_test.js
+++ b/tests/lib/context/basic_test.js
@@ -20,14 +20,14 @@ describe('A simple context with one resource', function() {
   });
 
   it('should return the string value of brandName', function(done) {
-    ctx.formatValue(langs, 'brandName').then(function(value) {
+    ctx.resolve(langs, 'brandName').then(function({value}) {
       assert.strictEqual(value, 'Firefox');
     }).then(done, done);
   });
 
   it('should return the value of about with the value' +
      ' of brandName in it', function(done) {
-    ctx.formatValue(langs, 'about').then(function(value) {
+    ctx.resolve(langs, 'about').then(function({value}) {
       assert.strictEqual(value, 'About Firefox');
     }).then(done, done);
   });
@@ -35,35 +35,35 @@ describe('A simple context with one resource', function() {
   it('should return the value of cert with the value of ' +
      'organization passed directly', function(done) {
     var args = {organization: 'Mozilla Foundation'};
-    ctx.formatValue(langs, 'cert', args).then(function(value) {
+    ctx.resolve(langs, 'cert', args).then(function({value}) {
       assert.strictEqual(value, 'Certificate signed by Mozilla Foundation');
     }).then(done, done);
   });
 
   it('should return the correct plural form for 0', function(done) {
     var args = {unread: 0};
-    ctx.formatValue(langs, 'unreadMessages', args).then(function(value) {
+    ctx.resolve(langs, 'unreadMessages', args).then(function({value}) {
       assert.strictEqual(value, '0 unread');
     }).then(done, done);
   });
 
   it('should return the correct plural form for 1', function(done) {
     var args = {unread: 1};
-    ctx.formatValue(langs, 'unreadMessages', args).then(function(value) {
+    ctx.resolve(langs, 'unreadMessages', args).then(function({value}) {
       assert.strictEqual(value, 'One unread');
     }).then(done, done);
   });
 
   it('should return the correct plural form for 2', function(done) {
     var args = {unread: 2};
-    ctx.formatValue(langs, 'unreadMessages', args).then(function(value) {
+    ctx.resolve(langs, 'unreadMessages', args).then(function({value}) {
       assert.strictEqual(value, '2 unread');
     }).then(done, done);
   });
 
   it('should return the correct plural form for 3', function(done) {
     var args = {unread: 3};
-    ctx.formatValue(langs, 'unreadMessages', args).then(function(value) {
+    ctx.resolve(langs, 'unreadMessages', args).then(function({value}) {
       assert.strictEqual(value, '3 unread');
     }).then(done, done);
   });

--- a/tests/lib/context/basic_test.js
+++ b/tests/lib/context/basic_test.js
@@ -13,9 +13,10 @@ const langs = [
 describe('A simple context with one resource', function() {
   var env, ctx;
 
-  beforeEach(function() {
+  beforeEach(function(done) {
     env = new Env('en-US', fetch);
     ctx = env.createContext([path + '/fixtures/basic.properties']);
+    ctx.fetch(langs).then(() => done(), done);
   });
 
   it('should return the string value of brandName', function(done) {

--- a/tests/lib/context/format_test.js
+++ b/tests/lib/context/format_test.js
@@ -19,9 +19,10 @@ function assertPromise(promise, expected, done) {
 describe('One fallback locale', function() {
   var env, ctx;
 
-  beforeEach(function() {
+  beforeEach(function(done) {
     env = new Env('en-US', fetch);
     ctx = env.createContext([path + '/fixtures/{locale}.properties']);
+    ctx.fetch(langs).then(() => done(), done);
   });
 
   describe('Translation in the first locale exists and is OK', function() {

--- a/tests/lib/context/format_test.js
+++ b/tests/lib/context/format_test.js
@@ -10,8 +10,8 @@ const langs = [
   { code: 'en-US', src: 'app', dir: 'ltr' },
 ];
 
-function assertPromise(promise, expected, done) {
-  promise.then(function(value) {
+function assertValue(promise, expected, done) {
+  promise.then(function({value}) {
     assert.strictEqual(value, expected);
   }).then(done, done);
 }
@@ -27,32 +27,32 @@ describe('One fallback locale', function() {
 
   describe('Translation in the first locale exists and is OK', function() {
     it('[e]', function(done) {
-      assertPromise(ctx.formatValue(langs, 'e'), 'E pl', done);
+      assertValue(ctx.resolve(langs, 'e'), 'E pl', done);
     });
   });
 
   describe('ValueError in first locale', function() {
     describe('Entity exists in second locale:', function() {
       it('[ve]', function(done) {
-        assertPromise(ctx.formatValue(langs, 've'), 'VE {{ boo }} pl', done);
+        assertValue(ctx.resolve(langs, 've'), 'VE {{ boo }} pl', done);
       });
     });
 
     describe('ValueError in second locale:', function() {
       it('[vv]', function(done) {
-        assertPromise(ctx.formatValue(langs, 'vv'), 'VV {{ boo }} pl', done);
+        assertValue(ctx.resolve(langs, 'vv'), 'VV {{ boo }} pl', done);
       });
     });
 
     describe('IndexError in second locale:', function() {
       it('[vi]', function(done) {
-        assertPromise(ctx.formatValue(langs, 'vi'), 'VI {{ boo }} pl', done);
+        assertValue(ctx.resolve(langs, 'vi'), 'VI {{ boo }} pl', done);
       });
     });
 
     describe('Entity missing in second locale:', function() {
       it('[vm]', function(done) {
-        assertPromise(ctx.formatValue(langs, 'vm'), 'VM {{ boo }} pl', done);
+        assertValue(ctx.resolve(langs, 'vm'), 'VM {{ boo }} pl', done);
       });
     });
   });
@@ -60,25 +60,25 @@ describe('One fallback locale', function() {
   describe('IndexError in first locale', function() {
     describe('Entity exists in second locale', function() {
       it('[ie]', function(done) {
-        assertPromise(ctx.formatValue(langs, 'ie'), 'ie', done);
+        assertValue(ctx.resolve(langs, 'ie'), 'ie', done);
       });
     });
 
     describe('ValueError in second locale', function() {
       it('[iv]', function(done) {
-        assertPromise(ctx.formatValue(langs, 'iv'), 'iv', done);
+        assertValue(ctx.resolve(langs, 'iv'), 'iv', done);
       });
     });
 
     describe('IndexError in second locale', function() {
       it('[ii]', function(done) {
-        assertPromise(ctx.formatValue(langs, 'ii'), 'ii', done);
+        assertValue(ctx.resolve(langs, 'ii'), 'ii', done);
       });
     });
 
     describe('Entity missing in second locale:', function() {
       it('[im]', function(done) {
-        assertPromise(ctx.formatValue(langs, 'im'), 'im', done);
+        assertValue(ctx.resolve(langs, 'im'), 'im', done);
       });
     });
   });
@@ -86,26 +86,26 @@ describe('One fallback locale', function() {
   describe('Entity not found in first locale', function() {
     describe('Entity exists in second locale:', function() {
       it('[me]', function(done) {
-        assertPromise(ctx.formatValue(langs, 'me'), 'ME en-US', done);
+        assertValue(ctx.resolve(langs, 'me'), 'ME en-US', done);
       });
     });
 
     describe('ValueError in second locale:', function() {
       it('[mv]', function(done) {
-        assertPromise(
-          ctx.formatValue(langs, 'mv'), 'MV {{ boo }} en-US', done);
+        assertValue(
+          ctx.resolve(langs, 'mv'), 'MV {{ boo }} en-US', done);
       });
     });
 
     describe('IndexError in second locale:', function() {
       it('[mi]', function(done) {
-        assertPromise(ctx.formatValue(langs, 'mi'), 'mi', done);
+        assertValue(ctx.resolve(langs, 'mi'), 'mi', done);
       });
     });
 
     describe('Entity missing in second locale:', function() {
       it('[mm]', function(done) {
-        assertPromise(ctx.formatValue(langs, 'mm'), 'mm', done);
+        assertValue(ctx.resolve(langs, 'mm'), 'mm', done);
       });
     });
   });


### PR DESCRIPTION
This is based on #55.

The distinction between `formatValue` and `formatEntity` makes the `Context` code more complex and creates an impression that attributes are second-class.  OTOH, the HTML bindings only use `formatEntity` anyways.  It's trivial to shim the bahavior of `formatValue` if needed.

Before:

```javascript
document.l10n.formatValue('foo').then(value => alert(value));
```
After:

```javascript
document.l10n.format('foo').then(({value}) => alert(value));
```