### PR TITLE
bug 1184498, error recovery by creating minimal and isolated JunkEntries

### DIFF
--- a/src/lib/format/l20n/ast/parser.js
+++ b/src/lib/format/l20n/ast/parser.js
@@ -55,16 +55,15 @@ export default {
 
     // now that we parsed the whole file and have all JunkEntries
     // glued together, let's run through them and create error messages
+    const that = Object.create(this);  // used as this for junk parsing
     resource._errors = resource.body.filter(function(node) {
       return node instanceof AST.JunkEntry;
     }).map(function(node) {
-      // extend this for just the junk content
-      const that = Object.create(exports.default);
       that._source = node.content;
       that._index = 0;
       that._length = node.content.length;
       try {
-        exports.default.getEntry.call(that);
+        that.getEntry();
       } catch (e) {
         if (node._pos) {
           e._pos.start += node._pos.start;

--- a/src/lib/format/l20n/ast/parser.js
+++ b/src/lib/format/l20n/ast/parser.js
@@ -26,11 +26,13 @@ export default {
     resource.setPosition(0, this._length);
 
     this.getWS();
+    let foundJunk = false;
     while (this._index < this._length) {
       try {
         resource.body.push(this.getEntry());
       } catch (e) {
         if (e instanceof L10nError) {
+          foundJunk = true;
           var currentJunk = this.getJunkEntry();
           var previous = resource.body[resource.body.length - 1];
           if (previous instanceof AST.JunkEntry) {
@@ -55,6 +57,11 @@ export default {
 
     // now that we parsed the whole file and have all JunkEntries
     // glued together, let's run through them and create error messages
+    // exit early if we don't need that
+    if (!foundJunk) {
+      resource._errors = [];
+      return resource;
+    }
     const that = Object.create(this);  // used as this for junk parsing
     resource._errors = resource.body.filter(function(node) {
       return node instanceof AST.JunkEntry;


### PR DESCRIPTION
When finding parser errors, make the JunkEntry as small as possible,
and continue parsing.
If there are adjancent JunkEntries, glue them together.
After parsing, getEntry on just the JunkEntry to create error messages.

Requesting feedback for now, we'd need to port this to the entries parser, too.