### PR TITLE
add grunt-cli so global install is not required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
   - "0.12"
-before_script:
-  - npm install -g grunt-cli
 notifications:
   irc:
     channels:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "commander": "~2.0",
     "grunt": "~0.4.1",
     "grunt-babel": "^5.0.0",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-jshint": "^0.11.1",


### PR DESCRIPTION
Without instructions, I cloned this repo, ran `$ npm install` and then `$ npm test`, which failed because `grunt` wasn't installed globally.

By adding `grunt-cli` to the `devDependencies`, a local `grunt` binary is created and doesn't require a global installation of `grunt` when using `grunt` via npm scripts.

This change also makes it unnecessary to install `grunt-cli` globally on Travis. Which I also removed.