### PR TITLE
Support IE 11

### DIFF
--- a/src/bindings/html/service.js
+++ b/src/bindings/html/service.js
@@ -22,14 +22,15 @@ export class Service {
       err => console.warn(err));
   }
 
-  requestLanguages(requestedLangs = navigator.languages) {
+  requestLanguages(requestedLangs) {
     return changeLanguages.call(
       this, getAdditionalLanguages(), requestedLangs);
   }
 
   handleEvent(evt) {
     return changeLanguages.call(
-      this, evt.detail || getAdditionalLanguages(), navigator.languages);
+      this, evt.detail || getAdditionalLanguages(),
+      navigator.languages || [navigator.language]);
   }
 }
 

--- a/src/runtime/web/index.js
+++ b/src/runtime/web/index.js
@@ -26,7 +26,7 @@ function init() {
   const service = new Service(fetch);
   window.addEventListener('languagechange', service);
   document.addEventListener('additionallanguageschange', service);
-  document.l10n.languages = navigator.languages;
+  document.l10n.languages = navigator.languages || [navigator.language];
 }
 
 whenInteractive(init);


### PR DESCRIPTION
I'd like to get us to a point where l20n.js works well in IE 11.  So far I discovered the following list of incompatibilities:

 - `navigator.languages` is undefined, need to use `[navigator.language]`,
 - no `WeakSet` but `Set` is available (#44 would help),
 - no `Promise`, needs a polyfill,
 - `CustomEvent` is not a constructor, need to use `document.createEvent`,
 - …?

I'll keep adding here if I find more. 

(The PR is a WIP.)