### PR TITLE
using docker builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "0.12"


### PR DESCRIPTION
If we're not using `sudo` for anything we can turn it off and get to use the faster docker containers offered by Travis.

http://docs.travis-ci.com/user/workers/container-based-infrastructure/