### PR TITLE
Bug 1206656 - Remove supportedlanguageschange event

### DIFF
--- a/docs/html.md
+++ b/docs/html.md
@@ -108,4 +108,4 @@ clarity):
 ```
 
 When all DOM nodes are localized, `document` will fire a `DOMLocalized` 
-event and will set its `localized` property to `true`.
+event and the `document.l10n.ready` promise will resolve.

--- a/src/bindings/html/view.js
+++ b/src/bindings/html/view.js
@@ -74,26 +74,22 @@ function onMutations(mutations) {
 }
 
 export function translate(langs) {
-  dispatchEvent(this.doc, 'supportedlanguageschange', langs);
   return translateDocument.call(this, langs);
 }
 
 function translateDocument(langs) {
   const [view, doc] = [this, this.doc];
-  const setDOMLocalized = function() {
-    doc.localized = true;
-    dispatchEvent(doc, 'DOMLocalized', langs);
-  };
 
   if (langs[0].code === doc.documentElement.getAttribute('lang')) {
-    return Promise.resolve(setDOMLocalized());
+    return Promise.resolve.then(
+      () => dispatchEvent(doc, 'DOMLocalized', langs));
   }
 
   return translateFragment(view, langs, doc.documentElement).then(
     () => {
       doc.documentElement.lang = langs[0].code;
       doc.documentElement.dir = langs[0].dir;
-      setDOMLocalized();
+      dispatchEvent(doc, 'DOMLocalized', langs);
     });
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1206656

We don't currently have a good use-case for this event and I think it'd be
safer if we removed it for now.  We're also not sure if it should be emitted by
the document or some other object.

If a need emerges in the future, we can re-add this event.  But first, I think
we should figure out where it fits in the NGA and which object is responsible
for emitting it.

In this commit I'm also removing document.localized which isn't very useful
right now (document.l10n.ready should be used instead).