### PR TITLE
Bug 1217312 - Use unicode instead of escape sequences for pseudo.

### DIFF
--- a/src/lib/pseudo.js
+++ b/src/lib/pseudo.js
@@ -95,26 +95,11 @@ function createGetter(id, name) {
     const reExcluded = /(%[EO]?\w|\{\s*.+?\s*\}|&[#\w]+;|<\s*.+?\s*>)/;
 
     const charMaps = {
-      // ȦƁƇḒḖƑƓĦĪĴĶĿḾȠǾƤɊŘŞŦŬṼẆẊẎẐ + [\\]^_` + ȧƀƈḓḗƒɠħīĵķŀḿƞǿƥɋřşŧŭṽẇẋẏẑ
       'qps-ploc':
-        '\u0226\u0181\u0187\u1E12\u1E16\u0191\u0193\u0126\u012A' +
-        '\u0134\u0136\u013F\u1E3E\u0220\u01FE\u01A4\u024A\u0158' +
-        '\u015E\u0166\u016C\u1E7C\u1E86\u1E8A\u1E8E\u1E90' +
-        '[\\]^_`' +
-        '\u0227\u0180\u0188\u1E13\u1E17\u0192\u0260\u0127\u012B' +
-        '\u0135\u0137\u0140\u1E3F\u019E\u01FF\u01A5\u024B\u0159' +
-        '\u015F\u0167\u016D\u1E7D\u1E87\u1E8B\u1E8F\u1E91',
-
-      // XXX Until https://bugzil.la/1007340 is fixed, ᗡℲ⅁⅂⅄ don't render well
-      // on the devices.  For now, use the following replacements: pɟפ˥ʎ
-      // ∀ԐↃpƎɟפHIſӼ˥WNOԀÒᴚS⊥∩ɅＭXʎZ + [\\]ᵥ_, + ɐqɔpǝɟƃɥıɾʞʅɯuodbɹsʇnʌʍxʎz
+        'ȦƁƇḒḖƑƓĦĪĴĶĿḾȠǾƤɊŘŞŦŬṼẆẊẎẐ[\\]^_`ȧƀƈḓḗƒɠħīĵķŀḿƞǿƥɋřşŧŭṽẇẋẏẑ',
       'qps-plocm':
-        '\u2200\u0510\u2183p\u018E\u025F\u05E4HI\u017F' +
-        '\u04FC\u02E5WNO\u0500\xD2\u1D1AS\u22A5\u2229\u0245' +
-        '\uFF2DX\u028EZ' +
-        '[\\]\u1D65_,' +
-        '\u0250q\u0254p\u01DD\u025F\u0183\u0265\u0131\u027E' +
-        '\u029E\u0285\u026Fuodb\u0279s\u0287n\u028C\u028Dx\u028Ez',
+        // XXX Use pɟפ˥ʎ as replacements for ᗡℲ⅁⅂⅄. https://bugzil.la/1007340
+        '∀ԐↃpƎɟפHIſӼ˥WNOԀÒᴚS⊥∩ɅＭXʎZ[\\]ᵥ_,ɐqɔpǝɟƃɥıɾʞʅɯuodbɹsʇnʌʍxʎz',
     };
 
     const mods = {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1217312