### PR TITLE
Allow class attribute for tags within translations.

### DIFF
--- a/src/bindings/html/overlay.js
+++ b/src/bindings/html/overlay.js
@@ -11,7 +11,8 @@ const allowed = {
     'mark', 'ruby', 'rt', 'rp', 'bdi', 'bdo', 'span', 'br', 'wbr'
   ],
   attributes: {
-    global: [ 'title', 'aria-label', 'aria-valuetext', 'aria-moz-hint' ],
+    global: [ 'title', 'aria-label', 'aria-valuetext', 'aria-moz-hint',
+      'class' ],
     a: [ 'download' ],
     area: [ 'download', 'alt' ],
     // value is special-cased in isAttrAllowed
@@ -192,4 +193,3 @@ function camelCaseToDashed(string) {
     })
     .replace(/^-/, '');
 }
-


### PR DESCRIPTION
This adds 'class' attribute to be used in tags within translations. 

One useful usecase allowed by this change is to be able to specify font awesome icons within a string. This is done by just inserting <i class="fa fa-paperclip"></i> within the string in the l20n file.