### PR TITLE
Switching unicode markers to bdi tags to fix MS browsers showing box characters in text.

### DIFF
--- a/src/lib/resolver.js
+++ b/src/lib/resolver.js
@@ -4,8 +4,8 @@ const KNOWN_MACROS = ['plural'];
 const MAX_PLACEABLE_LENGTH = 2500;
 
 // Unicode bidi isolation characters
-const FSI = '\u2068';
-const PDI = '\u2069';
+const FSI = '<bdi>';
+const PDI = '</bdi>';
 
 const resolutionChain = new WeakSet();
 

--- a/tests/lib/util.js
+++ b/tests/lib/util.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Unicode bidi isolation characters
-export const FSI = '\u2068';
-export const PDI = '\u2069';
+export const FSI = '<bdi>';
+export const PDI = '</bdi>';
 
 // > isolate('Hello, world.');
 // '\u2068Hello, world\u2069.'


### PR DESCRIPTION
The FSI and PDI characters are displayed as square boxes in Microsoft browsers (see attached screenshot). This pull request fixes that issue by using bdi tags instead.

![screen-shot-2016-03-22-at-8 05 49-pm](https://cloud.githubusercontent.com/assets/128726/13971833/cd40b6ae-f069-11e5-8788-124cbb4041c1.png)