### PR TITLE
Use generators and flatMap to handle errors and context

### DIFF
--- a/src/lib/builtins.js
+++ b/src/lib/builtins.js
@@ -10,6 +10,12 @@ class FTLBase {
   }
 }
 
+export class FTLNone extends FTLBase {
+  toString() {
+    return this.value || '???';
+  }
+}
+
 export class FTLNumber extends FTLBase {
   constructor(value, opts) {
     super(parseFloat(value), opts);

--- a/src/lib/builtins.js
+++ b/src/lib/builtins.js
@@ -20,9 +20,9 @@ export class FTLNumber extends FTLBase {
   constructor(value, opts) {
     super(parseFloat(value), opts);
   }
-  toString(rc) {
-    const nf = rc.ctx._memoizeIntlObject(
-      L20nIntl.NumberFormat, rc.lang, this.opts
+  toString(ctx, lang) {
+    const nf = ctx._memoizeIntlObject(
+      L20nIntl.NumberFormat, lang, this.opts
     );
     return nf.format(this.value);
   }
@@ -32,9 +32,9 @@ export class FTLDateTime extends FTLBase {
   constructor(value, opts) {
     super(new Date(value), opts);
   }
-  toString(rc) {
-    const dtf = rc.ctx._memoizeIntlObject(
-      L20nIntl.DateTimeFormat, rc.lang, this.opts
+  toString(ctx, lang) {
+    const dtf = ctx._memoizeIntlObject(
+      L20nIntl.DateTimeFormat, lang, this.opts
     );
     return dtf.format(this.value);
   }
@@ -45,7 +45,7 @@ export class FTLKeyword extends FTLBase {
     const { name, namespace } = this.value;
     return namespace ? `${namespace}:${name}` : name;
   }
-  match(rc, other) {
+  match(ctx, lang, other) {
     const { name, namespace } = this.value;
     if (other instanceof FTLKeyword) {
       return name === other.value.name && namespace === other.value.namespace;
@@ -54,8 +54,8 @@ export class FTLKeyword extends FTLBase {
     } else if (typeof other === 'string') {
       return name === other;
     } else if (other instanceof FTLNumber) {
-      const pr = rc.ctx._memoizeIntlObject(
-        L20nIntl.PluralRules, rc.lang, other.opts
+      const pr = ctx._memoizeIntlObject(
+        L20nIntl.PluralRules, lang, other.opts
       );
       return name === pr.select(other.valueOf());
     }
@@ -63,12 +63,12 @@ export class FTLKeyword extends FTLBase {
 }
 
 export class FTLList extends Array {
-  toString(rc) {
-    const lf = rc.ctx._memoizeIntlObject(
-      L20nIntl.ListFormat, rc.lang // XXX add this.opts
+  toString(ctx, lang) {
+    const lf = ctx._memoizeIntlObject(
+      L20nIntl.ListFormat, lang // XXX add this.opts
     );
     const elems = this.map(
-      elem => elem.toString(rc)
+      elem => elem.toString(ctx, lang)
     );
     return lf.format(elems);
   }

--- a/src/lib/readwrite.js
+++ b/src/lib/readwrite.js
@@ -20,10 +20,6 @@ export function ask() {
   return new ReadWrite(ctx => [ctx, []]);
 }
 
-export function tell(log) {
-  return new ReadWrite(() => [null, [log]]);
-}
-
 export function unit(val) {
   return new ReadWrite(() => [val, []]);
 }

--- a/src/lib/readwrite.js
+++ b/src/lib/readwrite.js
@@ -20,12 +20,12 @@ export function ask() {
   return new ReadWrite(ctx => [ctx, []]);
 }
 
-export function unit(val) {
-  return new ReadWrite(() => [val, []]);
+export function tell(log) {
+  return new ReadWrite(() => [null, [log]]);
 }
 
-export function fail(val, log) {
-  return new ReadWrite(() => [val, [log]]);
+export function unit(val) {
+  return new ReadWrite(() => [val, []]);
 }
 
 export function resolve(iter) {

--- a/src/lib/readwrite.js
+++ b/src/lib/readwrite.js
@@ -1,0 +1,42 @@
+class ReadWrite {
+  constructor(fn) {
+    this.fn = fn;
+  }
+
+  run(ctx) {
+    return this.fn(ctx);
+  }
+
+  flatMap(fn) {
+    return new ReadWrite(ctx => {
+      const [cur, curErrs] = this.run(ctx);
+      const [val, valErrs] = fn(cur).run(ctx);
+      return [val, [...curErrs, ...valErrs]];
+    });
+  }
+}
+
+export function ask() {
+  return new ReadWrite(ctx => [ctx, []]);
+}
+
+export function tell(log) {
+  return new ReadWrite(() => [null, [log]]);
+}
+
+export function unit(val) {
+  return new ReadWrite(() => [val, []]);
+}
+
+export function fail(val, log) {
+  return new ReadWrite(() => [val, [log]]);
+}
+
+export function resolve(iter) {
+  return function step(resume) {
+    const {value, done} = iter.next(resume);
+    const rw = (value instanceof ReadWrite) ?
+      value : unit(value);
+    return done ? rw : rw.flatMap(step);
+  }();
+}

--- a/src/lib/resolver.js
+++ b/src/lib/resolver.js
@@ -43,7 +43,7 @@ function* EntityReference(expr) {
 
   if (!entity) {
     yield err(`Unknown entity: ${expr.name}`);
-    return FTLNone(expr.name);
+    return new FTLNone(expr.name);
   }
 
   return entity;

--- a/src/lib/resolver.js
+++ b/src/lib/resolver.js
@@ -1,4 +1,5 @@
 import { L10nError } from './errors';
+import { resolve, ask, tell, fail } from './readwrite';
 import builtins, {
   FTLNumber, FTLDateTime, FTLKeyword, FTLList
 } from './builtins';
@@ -9,261 +10,254 @@ const PDI = '\u2069';
 
 const MAX_PLACEABLE_LENGTH = 2500;
 
-function mapValues(rc, arr) {
-  return arr.reduce(
-    ([valseq, errseq], cur) => {
-      const [value, errs] = Value(rc, cur);
-      return [valseq.concat(value), errseq.concat(errs)];
-    }, [new FTLList(), []]
-  );
+function* mapValues(arr) {
+  let values = new FTLList();
+  for (let elem of arr) {
+    values.push(yield* Value(elem));
+  }
+  return values;
 }
-
-function unit(val) {
-  return [val, []];
-}
-
-function fail(val, err) {
-  return [val, [err]];
-}
-
-function flat([val, errs2], errs1) {
-  return [val, [...errs1, ...errs2]];
-}
-
 
 // Helper for choosing entity value
 
-function DefaultMember(members) {
+function* DefaultMember(members) {
   for (let member of members) {
     if (member.def) {
-      return unit(member);
+      return yield member;
     }
   }
 
-  return fail('???', new L10nError('No default'));
+  return yield fail('???', new L10nError('No default'));
 }
 
 
 // Half-resolved expressions
 
-function Expression(rc, expr) {
+function* Expression(expr) {
   switch (expr.type) {
     case 'ref':
-      return EntityReference(rc, expr);
+      return yield* EntityReference(expr);
     case 'blt':
-      return BuiltinReference(rc, expr);
+      return yield* BuiltinReference(expr);
     case 'mem':
-      return MemberExpression(rc, expr);
+      return yield* MemberExpression(expr);
     case 'sel':
-      return SelectExpression(rc, expr);
+      return yield* SelectExpression(expr);
     default:
-      return unit(expr);
+      return yield expr;
   }
 }
 
-function EntityReference(rc, expr) {
+function* EntityReference(expr) {
+  const rc = yield ask();
   const entity = rc.ctx._getEntity(rc.lang, expr.name);
 
   if (!entity) {
-    return fail(expr.name, new L10nError('Unknown entity: ' + expr.name));
+    return yield fail(expr.name, new L10nError('Unknown entity: ' + expr.name));
   }
 
-  return unit(entity);
+  return yield entity;
 }
 
-function BuiltinReference(rc, expr) {
+function* BuiltinReference(expr) {
   const builtin = builtins[expr.name];
 
   if (!builtin) {
-    return fail(
+    return yield fail(
       expr.name + '()', new L10nError('Unknown built-in: ' + expr.name + '()')
     );
   }
 
-  return unit(builtin);
+  return yield builtin;
 }
 
-function MemberExpression(rc, expr) {
-  const [entity, errs] = Expression(rc, expr.obj);
-  if (errs.length) {
-    return [entity, errs];
-  }
-
-  const [key] = Value(rc, expr.key);
+function* MemberExpression(expr) {
+  const entity = yield* Expression(expr.obj);
+  const key = yield* Value(expr.key);
+  const rc = yield ask();
 
   for (let member of entity.traits) {
-    const [memberKey] = Value(rc, member.key);
+    const memberKey = yield* Value(member.key);
     if (key.match(rc, memberKey)) {
-      return unit(member);
+      return yield member;
     }
   }
 
-  return fail(entity, new L10nError('Unknown trait: ' + key.toString(rc)));
+  return yield fail(entity, new L10nError('Unknown trait: ' + key.toString(rc)));
 }
 
-function SelectExpression(rc, expr) {
-  const [selector, errs] = Value(rc, expr.exp);
-  if (errs.length) {
-    return flat(DefaultMember(expr.vars), errs);
-  }
+function* SelectExpression(expr) {
+  const selector = yield* Value(expr.exp);
+  // if (errs.length) {
+  //   return flat(DefaultMember(expr.vars), errs);
+  // }
 
   for (let variant of expr.vars) {
-    const [key] = Value(rc, variant.key);
+    const key = yield* Value(variant.key);
 
     if (key instanceof FTLNumber &&
         selector instanceof FTLNumber &&
         key.valueOf() === selector.valueOf()) {
-      return unit(variant);
+      return yield variant;
     }
+
+    const rc = yield ask();
 
     if (key instanceof FTLKeyword &&
         key.match(rc, selector)) {
-      return unit(variant);
+      return yield variant;
     }
   }
 
-  return DefaultMember(expr.vars);
+  return yield* DefaultMember(expr.vars);
 }
 
 
 // Fully-resolved expressions
 
-function Value(rc, expr) {
+function* Value(expr) {
   if (typeof expr === 'string' || expr === null) {
-    return unit(expr);
+    return yield expr;
   }
 
   if (Array.isArray(expr)) {
-    return Pattern(rc, expr);
+    return yield* Pattern(expr);
   }
 
-  const [node, errs] = Expression(rc, expr);
-  if (errs.length) {
-    // Expression short-circuited into a simple string or a fallback
-    return flat(Value(rc, node), errs);
-  }
+  const node = yield* Expression(expr);
+  // if (errs.length) {
+  //   // Expression short-circuited into a simple string or a fallback
+  //   return flat(Value(rc, node), errs);
+  // }
 
   switch (node.type) {
     case 'kw':
-      return [new FTLKeyword(node), errs];
+      return yield new FTLKeyword(node);
     case 'num':
-      return [new FTLNumber(node.val), errs];
+      return yield new FTLNumber(node.val);
     case 'ext':
-      return flat(ExternalArgument(rc, node), errs);
+      return yield* ExternalArgument(node);
     case 'call':
-      return flat(CallExpression(rc, expr), errs);
+      return yield* CallExpression(expr);
     default:
       return node.key ? // is it a Member?
-        flat(Value(rc, node.val), errs) :
-        flat(Entity(rc, node), errs);
+        yield* Value(node.val) :
+        yield* Entity(node);
   }
 }
 
-function ExternalArgument(rc, expr) {
+function* ExternalArgument(expr) {
   const name = expr.name;
-  const args = rc.args;
+  const { args } = yield ask();
 
   if (!args || !args.hasOwnProperty(name)) {
-    return fail(name, new L10nError('Unknown external: ' + name));
+    return yield fail(name, new L10nError('Unknown external: ' + name));
   }
 
   const arg = args[name];
 
   switch (typeof arg) {
     case 'string':
-      return unit(arg);
+      return yield arg;
     case 'number':
-      return unit(new FTLNumber(arg));
+      return yield new FTLNumber(arg);
     case 'object':
       if (Array.isArray(arg)) {
-        return mapValues(rc, arg);
+        return yield* mapValues(arg);
       }
       if (arg instanceof Date) {
-        return unit(new FTLDateTime(arg));
+        return yield new FTLDateTime(arg);
       }
     default:
-      return fail(name, new L10nError(
+      return yield fail(name, new L10nError(
         'Unsupported external type: ' + name + ', ' + typeof arg
       ));
   }
 }
 
-function CallExpression(rc, expr) {
-  const [callee, errs1] = Expression(rc, expr.name);
-  if (errs1.length) {
-    return [callee, errs1];
+function* CallExpression(expr) {
+  const callee = yield* Expression(expr.name);
+
+  // if (errs1.length) {
+  //   return [callee, errs1];
+  // }
+
+  let pargs = [];
+  let kargs = [];
+
+  for (let arg of expr.args) {
+    if (arg.type === 'kv') {
+      const val = yield* Value(arg.val);
+      kargs[arg.name] = val;
+    } else {
+      const val = yield* Value(arg);
+      pargs.push(val);
+    }
   }
 
-  const [pargs, kargs, errs2] = expr.args.reduce(
-    ([pargseq, kargseq, errseq], arg) => {
-      if (arg.type === 'kv') {
-        const [val, errs] = Value(rc, arg.val);
-        kargseq[arg.name] = val;
-        return [pargseq, kargseq, [...errseq, ...errs]];
-      } else {
-        const [val, errs] = Value(rc, arg);
-        return [[...pargseq, val], kargseq, [...errseq, ...errs]];
-      }
-    }, [[], {}, []]);
-  return [callee(pargs, kargs), errs2];
+  return yield callee(pargs, kargs);
 }
 
-function Pattern(rc, ptn) {
+function* Pattern(ptn) {
+  const rc = yield ask();
+
   if (rc.dirty.has(ptn)) {
-    return fail('???', new L10nError('Cyclic reference'));
+    return yield fail('???', new L10nError('Cyclic reference'));
   }
 
   rc.dirty.add(ptn);
 
-  const rv = ptn.reduce(([valseq, errseq], elem) => {
-    if (typeof elem === 'string') {
-      return [valseq + elem, errseq];
+  let result = '';
+
+  for (let part of ptn) {
+    if (typeof part === 'string') {
+      result += part;
     } else {
-      const [value, errs] = elem.length === 1 ?
-        Value(rc, elem[0]) : mapValues(rc, elem);
+      const value = part.length === 1 ?
+        yield* Value(part[0]) : yield* mapValues(part);
+
       const str = value.toString(rc);
       if (str.length > MAX_PLACEABLE_LENGTH) {
-        return [
-          valseq + '???',
-          [...errseq, ...errs, new L10nError(
-            'Too many characters in placeable ' +
-            `(${str.length}, max allowed is ${MAX_PLACEABLE_LENGTH})`
-          )]
-        ];
+        yield tell(new L10nError(
+          'Too many characters in placeable ' +
+          `(${str.length}, max allowed is ${MAX_PLACEABLE_LENGTH})`
+        ));
+        result += '???';
+      } else {
+        result += FSI + str + PDI;
       }
-      return [
-        valseq + FSI + str + PDI, [...errseq, ...errs],
-      ];
     }
-
-  }, ['', []]);
+  }
 
   rc.dirty.delete(ptn);
-  return rv;
+  return yield result;
 }
 
-function Entity(rc, entity) {
+function* Entity(entity) {
   if (!entity.traits) {
-    return Value(rc, entity);
+    return yield* Value(entity);
   }
 
   if (entity.val !== undefined) {
-    return Value(rc, entity.val);
+    return yield* Value(entity.val);
   }
 
-  const [def, errs] = DefaultMember(entity.traits);
-  return flat(Value(rc, def), errs);
+  const def = yield* DefaultMember(entity.traits);
+  return yield* Value(def);
 }
 
 
 export function format(ctx, lang, args, entity) {
-  // rc is the current resolution context
-  const rc = {
+  const res = resolve(function* () {
+    return yield* Value(entity);
+  }());
+
+  const ret = res.run({
     ctx,
     lang,
     args,
     dirty: new WeakSet()
-  };
+  });
 
-  return Value(rc, entity);
+  return ret;
 }

--- a/src/lib/resolver.js
+++ b/src/lib/resolver.js
@@ -1,5 +1,5 @@
 import { L10nError } from './errors';
-import { resolve, ask, tell, fail } from './readwrite';
+import { resolve, ask, fail } from './readwrite';
 import builtins, {
   FTLNone, FTLNumber, FTLDateTime, FTLKeyword, FTLList
 } from './builtins';

--- a/src/lib/resolver.js
+++ b/src/lib/resolver.js
@@ -44,7 +44,7 @@ function* EntityReference(expr) {
     return yield err(`Unknown entity: ${expr.name}`, expr.name);
   }
 
-  return yield entity;
+  return entity;
 }
 
 function* BuiltinReference(expr) {
@@ -54,7 +54,7 @@ function* BuiltinReference(expr) {
     return yield err(`Unknown built-in: ${expr.name}()`, `${expr.name}()`);
   }
 
-  return yield builtin;
+  return builtin;
 }
 
 function* MemberExpression(expr) {
@@ -65,7 +65,7 @@ function* MemberExpression(expr) {
   for (let member of entity.traits) {
     const memberKey = yield* Value(member.key);
     if (key.match(rc, memberKey)) {
-      return yield member;
+      return member;
     }
   }
 
@@ -84,14 +84,14 @@ function* SelectExpression(expr) {
     if (key instanceof FTLNumber &&
         selector instanceof FTLNumber &&
         key.valueOf() === selector.valueOf()) {
-      return yield variant;
+      return variant;
     }
 
     const rc = yield ask();
 
     if (key instanceof FTLKeyword &&
         key.match(rc, selector)) {
-      return yield variant;
+      return variant;
     }
   }
 
@@ -103,7 +103,7 @@ function* SelectExpression(expr) {
 
 function* Value(expr) {
   if (typeof expr === 'string' || expr === null) {
-    return yield expr;
+    return expr;
   }
 
   if (Array.isArray(expr)) {
@@ -112,9 +112,9 @@ function* Value(expr) {
 
   switch (expr.type) {
     case 'kw':
-      return yield new FTLKeyword(expr);
+      return new FTLKeyword(expr);
     case 'num':
-      return yield new FTLNumber(expr.val);
+      return new FTLNumber(expr.val);
     case 'ext':
       return yield* ExternalArgument(expr);
     case 'call':
@@ -148,15 +148,15 @@ function* ExternalArgument(expr) {
 
   switch (typeof arg) {
     case 'string':
-      return yield arg;
+      return arg;
     case 'number':
-      return yield new FTLNumber(arg);
+      return new FTLNumber(arg);
     case 'object':
       if (Array.isArray(arg)) {
         return yield* mapValues(arg);
       }
       if (arg instanceof Date) {
-        return yield new FTLDateTime(arg);
+        return new FTLDateTime(arg);
       }
     default:
       return yield err(
@@ -219,7 +219,7 @@ function* Pattern(ptn) {
   }
 
   rc.dirty.delete(ptn);
-  return yield result;
+  return result;
 }
 
 function* Entity(entity) {

--- a/src/lib/resolver.js
+++ b/src/lib/resolver.js
@@ -172,20 +172,19 @@ function* CallExpression(expr) {
     return callee;
   }
 
-  let pargs = [];
-  let kargs = [];
+  const posargs = [];
+  const keyargs = [];
 
   for (let arg of expr.args) {
     if (arg.type === 'kv') {
-      const val = yield* Value(arg.val);
-      kargs[arg.name] = val;
+      keyargs[arg.name] = yield* Value(arg.val);
     } else {
-      const val = yield* Value(arg);
-      pargs.push(val);
+      posargs.push(yield* Value(arg));
     }
   }
 
-  return yield callee(pargs, kargs);
+  // XXX builtins should also returns [val, errs] tuples
+  return callee(posargs, keyargs);
 }
 
 function* Pattern(ptn) {

--- a/src/lib/resolver.js
+++ b/src/lib/resolver.js
@@ -247,13 +247,16 @@ function* Entity(entity) {
   return yield* Value(def);
 }
 
+function* valueOf(entity) {
+  return yield* Value(entity);
+}
 
 export function format(ctx, lang, args, entity) {
-  const res = resolve(function* () {
-    return yield* Value(entity);
-  }());
+  if (typeof entity === 'string') {
+    return [entity, []];
+  }
 
-  return res.run({
+  return resolve(valueOf(entity)).run({
     ctx, lang, args, dirty: new WeakSet()
   });
 }


### PR DESCRIPTION
It has always bugged me that we need to pass the `ctx` and `args` into all functions of the resolver.  And returning `[value, errors]` tuples to 1) allow for better and more graceful fallback and 2) avoid `try…catch` meant that composing functions was a nightmare.

I'd like to suggest a pattern which abstracts the extra output (errors) and extra input (context data) away from the actual code of the resolver.  Thanks to generators a wrapper function can handle these side effects (right when `yield` is called and the actual function is suspended) and—once ready—it can inject just the values that the resolver cares about back into its code (with the iterator's `next()` method).

The code becomes much clearer and cleaner IMO, and the tedious task of handling errors is no more.  There's a performance penalty related to using generators (which I hope one day will be optimized in the engine).  Compared to my recent changes which brought the benchmark down to 10 ms on my machine using jsshell, we're back to 15-16 ms, which is what I started with this morning.

compared to current master:

    mean:   16104.7 (+60%)
    stdev:  558.54
    sample: 30

compared to yesterday's master:

    mean:   16044.4 (+3%)
    stdev:  760.71
    sample: 30

You could say I had won these 5 ms to be able to suggest this change :)

We can probably look for other optimizations (which will be easier now that the code is easier to modify) and try to go down to 10 ms again.  @zbraniecki, what do you think?
