### PR TITLE
Add FTLASTSerializer to node js module

### DIFF
--- a/src/runtime/node/index.js
+++ b/src/runtime/node/index.js
@@ -1,5 +1,6 @@
 import '../../intl/polyfill';
 
+export { default as FTLASTSerializer } from '../../ftl/ast/serializer';
 export { default as FTLASTParser } from '../../ftl/ast/parser';
 export { default as FTLEntriesParser } from '../../ftl/entries/parser';
 export { createEntriesFromAST } from '../../ftl/entries/transformer';


### PR DESCRIPTION
Let me to describe why I need this change. 
I'd like to use a ready l20n.js node js module but I can't do it now.

I convert arrays like:
```
["{ $num } new notification", "{ $num } new notifications"]
```
into l20n value
```
{ PLURAL($num) -> 
  [one] { $num } new notification.
 *[other] { $num } new notifications.
}
```

I need `FTLASTSerializer.dumpPattern()` method which is not in node.js bundled module.