### PR TITLE
Nullify error resources

### DIFF
--- a/src/runtime/node/io.js
+++ b/src/runtime/node/io.js
@@ -1,13 +1,12 @@
 /* jshint node:true */
 
 import { readFile } from 'fs';
-import { L10nError } from '../../lib/errors';
 
 function load(url) {
   return new Promise((resolve, reject) => {
     readFile(url, (err, data) => {
       if (err) {
-        reject(new L10nError(err.message));
+        reject(err);
       } else {
         resolve(data.toString());
       }
@@ -17,5 +16,5 @@ function load(url) {
 
 export function fetchResource(res, { code }) {
   const url = res.replace('{locale}', code);
-  return load(url).catch(e => e);
+  return load(url).catch(() => null);
 }

--- a/src/runtime/web/io.js
+++ b/src/runtime/web/io.js
@@ -1,5 +1,3 @@
-import { L10nError } from '../../lib/errors';
-
 const HTTP_STATUS_CODE_OK = 200;
 
 function load(url) {
@@ -15,13 +13,18 @@ function load(url) {
     xhr.addEventListener('load', e => {
       if (e.target.status === HTTP_STATUS_CODE_OK ||
           e.target.status === 0) {
-        resolve(e.target.response);
+        resolve(e.target.responseText);
       } else {
-        reject(new L10nError(`Not found: ${url}`));
+        reject(new Error(`${url} not found`));
       }
     });
-    xhr.addEventListener('error', reject);
-    xhr.addEventListener('timeout', reject);
+
+    xhr.addEventListener('error',
+      () => reject(new Error(`${url} failed to load`))
+    );
+    xhr.addEventListener('timeout',
+      () => reject(new Error(`${url} timed out`))
+    );
 
     xhr.send(null);
   });
@@ -29,7 +32,7 @@ function load(url) {
 
 export function fetchResource(res, lang) {
   const url = res.replace('{locale}', lang);
-  return load(url).catch(e => e);
+  return load(url).catch(() => null);
 }
 
 export class ResourceBundle {


### PR DESCRIPTION
This is consistent with how we handle errors in Gecko's `toolkit/modules/L10nRegistry.jsm`. Testing if a resource returned from the IO module is `null` is enough to know if there was an error.  True error reporting should be done in the IO module.  The reason why we can't test `instanceof Error` anymore is that an `Error` in a JSM is not the same things as the `Error` in chrome/content code.

This fixed examples/web.html in the language switching scenario (examples are missing one of the resources in French—on purpose).

@zbraniecki r?