### PR TITLE
Fix for using hyperlinks in the FTL files

### DIFF
--- a/src/bindings/overlay.js
+++ b/src/bindings/overlay.js
@@ -14,7 +14,7 @@ const ALLOWED_ELEMENTS = {
 const ALLOWED_ATTRIBUTES = {
   'http://www.w3.org/1999/xhtml': {
     global: ['title', 'aria-label', 'aria-valuetext', 'aria-moz-hint'],
-    a: ['download'],
+    a: ['href', 'download'],
     area: ['download', 'alt'],
     // value is special-cased in isAttrAllowed
     input: ['alt', 'placeholder'],

--- a/src/intl/resolver.js
+++ b/src/intl/resolver.js
@@ -282,6 +282,26 @@ function FunctionReference(env, {name}) {
 }
 
 /**
+ * To check if a string is an URL or not.
+ *
+ * @private
+ */
+function IsURL(url) {
+  const strRegex = '^((https|http|ftp|rtsp|mms)?://)'
+    + "?(([0-9a-z_!~*'().&=+$%-]+: )?[0-9a-z_!~*'().&=+$%-]+@)?" // ftp user@
+    + '(([0-9]{1,3}\\.){3}[0-9]{1,3}' // IP URL- 199.194.52.184
+    + '|' // IP DOMAIN
+    + "([0-9a-z_!~*'()-]+\\.)*" // www.
+    + '([0-9a-z][0-9a-z-]{0,61})?[0-9a-z]\\.' // 二
+    + '[a-z]{2,6})' // first level domain- .com or .museum
+    + '(:[0-9]{1,4})?' // :80
+    + '((/?)|' // a slash isn't required if there is no file name
+    + "(/[0-9a-z_!~*'().;?:@&=+$,%#-]+)+/?)$";
+  const re = new RegExp(strRegex);
+  return re.test(url);
+}
+
+/**
  * Resolve a call to a Function with positional and key-value arguments.
  *
  * @private
@@ -346,7 +366,7 @@ function Pattern(env, ptn) {
         str = str.substr(0, MAX_PLACEABLE_LENGTH);
       }
 
-      if (ctx.useIsolating) {
+      if (ctx.useIsolating && !IsURL(str)) {
         result += `${FSI}${str}${PDI}`;
       } else {
         result += str;


### PR DESCRIPTION
ALLOWED_ATTRIBUTES for `a` do not have attribute `href` - that is why hyperlinks do not work in the FTL files.