### PR TITLE
Disable FSI/PDI isolating on IE11

### DIFF
--- a/src/web/index.js
+++ b/src/web/index.js
@@ -14,7 +14,11 @@ import { documentReady, getResourceLinks, getMeta } from './util';
 // used to create new `MessageContext` objects for a given `lang` with selected
 // builtin functions.
 function createContext(lang) {
-  return new MessageContext(lang);
+  // IE11 renders FSI and PDI as mojibakes so we turn them off.
+  const isIE11 = navigator.userAgent.indexOf('Trident') > -1;
+  return new MessageContext(lang, {
+    useIsolating: !isIE11
+  });
 }
 
 // Called for every named Localization declared via <link name=…> elements.


### PR DESCRIPTION
IE11 on Windows renders FSI and PDI as mojibakes. Let's turn isolating off when this browser is detected.